### PR TITLE
Feature: PathBuilder and AwsUtils tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ local.properties
 */.gradle/
 /build/
 
+# VSCode
+.vscode
+
 # iOS
 .DS_Store
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,9 @@ local.properties
 
 # iOS
 .DS_Store
+
+# Python
+__pycache__
+.venv
+.pytest_cache
+.coverage*

--- a/python/idsse_common/README.md
+++ b/python/idsse_common/README.md
@@ -53,11 +53,13 @@ this. The initial packaging for the project uses [setuptools](https://setuptools
 
 ## Build and Install
 
-To manually install the package on your local instance pull the data-access-service from the repository and go into idsse_common
+To manually install the package on your local instance pull the idss-engine-common from the repository and navigate into idsse_common
 
-From the project root directory `data-access-service/idsse_common`:
+From the directory `/idss-engine-common/python/idsse_common`:
 
 `$ python3 setup.py install`
+
+**NOTE** Python 3.11+ is required to install and use this package, it won't work on earlier versions of python
 
 ## Using the package
 

--- a/python/idsse_common/README.md
+++ b/python/idsse_common/README.md
@@ -53,13 +53,11 @@ this. The initial packaging for the project uses [setuptools](https://setuptools
 
 ## Build and Install
 
-To manually install the package on your local instance pull the `idss-engine-commons` project from the repository and navigate into idsse_common
+To manually install the package on your local instance pull the data-access-service from the repository and go into idsse_common
 
-From the directory `idss-engine-commons/python/idsse_common`:
+From the project root directory `data-access-service/idsse_common`:
 
 `$ python3 setup.py install`
-
-**NOTE** Python 3.11+ is required to install and use this package, it won't work on earlier versions of python
 
 ## Using the package
 
@@ -68,4 +66,13 @@ Once installed elements from the package can be imported directly into code. For
 ---
 > from idsse.common.path_builder import PathBuilder
 
+## Running tests
+### Python
+After installing the project's dependencies, make sure you have the [pytest-cov](https://pytest-cov.readthedocs.io/en/latest/config.html?highlight=missing#reference) plugin installed. 
 
+Run pytest coverage with the following CLI command. Note: the path argument can be removed to run all tests in the project.
+```
+pytest --cov=python/idsse_common python/idsse_common/test --cov-report=term-missing
+```
+
+Add the following parameter

--- a/python/idsse_common/README.md
+++ b/python/idsse_common/README.md
@@ -74,5 +74,3 @@ Run pytest coverage with the following CLI command. Note: the path argument can 
 ```
 pytest --cov=python/idsse_common python/idsse_common/test --cov-report=term-missing
 ```
-
-Add the following parameter

--- a/python/idsse_common/idsse/common/aws_utils.py
+++ b/python/idsse_common/idsse/common/aws_utils.py
@@ -53,10 +53,10 @@ class AwsUtils():
             Sequence[str]: The results sent to stdout from executing an 'ls' on passed path
         """
         try:
-            commands = ["s5cmd",  "--no-sign-request", "ls", path]
+            commands = ['s5cmd',  '--no-sign-request', 'ls', path]
             commands_result = exec_cmd(commands)
         except FileNotFoundError:
-            commands = ["aws", "s3",  "--no-sign-request", "ls", path]
+            commands = ['aws', 's3',  '--no-sign-request', 'ls', path]
             commands_result = exec_cmd(commands)
         except PermissionError:
             return []
@@ -76,13 +76,13 @@ class AwsUtils():
         """
         try:
             logger.debug('First attempt with s5cmd')
-            commands = ["s5cmd", "--no-sign-request",  "cp", path, dest]
+            commands = ['s5cmd', '--no-sign-request',  'cp', path, dest]
             exec_cmd(commands)
             return True
         except FileNotFoundError:
             try:
                 logger.debug('Second attempt with aws command line')
-                commands = ["aws", "s3", "--no-sign-request",  "cp", path, dest]
+                commands = ['aws', 's3', '--no-sign-request',  'cp', path, dest]
                 exec_cmd(commands)
                 return True
             except:

--- a/python/idsse_common/idsse/common/aws_utils.py
+++ b/python/idsse_common/idsse/common/aws_utils.py
@@ -85,9 +85,11 @@ class AwsUtils():
                 commands = ["aws", "s3", "--no-sign-request",  "cp", path, dest]
                 exec_cmd(commands)
                 return True
+            except:
+                return False
             finally:
                 pass
-        return False
+       
 
     def check_for(self, issue: datetime, valid: datetime) -> Tuple[datetime, str]:
         """Checks if an object passed issue/valid exists
@@ -113,7 +115,7 @@ class AwsUtils():
                    num_issues: int = 1,
                    issue_start: datetime = None,
                    issue_end: datetime = datetime.now(timezone.utc)
-                   ) -> Sequence[Tuple[datetime, str]]:
+                   ) -> Sequence[datetime]:
         """Determine the available issue date/times
 
         Args:
@@ -122,7 +124,7 @@ class AwsUtils():
             issue_end (datetime, optional): The newest date/time to look for. Defaults to None.
 
         Returns:
-            Sequence[Tuple[datetime, str]]: A sequence of issue date/time and filepath
+            Sequence[Tuple[datetime, str]]: A sequence of issue date/times
         """
         issues_found = []
         if issue_start:
@@ -185,29 +187,3 @@ class AwsUtils():
                           if valid <= valid_end]
 
         return valid_file
-
-
-def _test():
-    basedir = 's3://noaa-nbm-grib2-pds/'
-    subdir = 'blend.{issue.year:04d}{issue.month:02d}{issue.day:02d}/{issue.hour:02d}/core/'
-    file_base = 'blend.t{issue.hour:02d}z.core.f{lead.hour:03d}'
-    file_ext = '.co.grib2'
-
-    issue = datetime(2023, 2, 12, 14)
-    aws_util = AwsUtils(basedir, subdir, file_base, file_ext)
-    ls_result = [valid for valid, _ in aws_util.get_valids(issue=issue)]
-    logging.info(ls_result)
-
-
-if __name__ == '__main__':
-    import sys
-
-    logging.basicConfig(
-        level=logging.INFO,
-        format='%(asctime)s - %(module)s - %(levelname)s : %(message)s',
-        handlers=[
-            logging.StreamHandler(sys.stdout)
-        ]
-    )
-
-    _test()

--- a/python/idsse_common/test/test_aws_utils.py
+++ b/python/idsse_common/test/test_aws_utils.py
@@ -51,14 +51,14 @@ def mock_exec_cmd(monkeypatch: MonkeyPatch) -> Mock:
 
 def test_get_path(aws_utils: AwsUtils):
     result_path = aws_utils.get_path(EXAMPLE_ISSUE, EXAMPLE_VALID)
-    assert result_path == f"{EXAMPLE_DIR}/blend.t12z.core.f002.co.grib2"
+    assert result_path == f'{EXAMPLE_DIR}/blend.t12z.core.f002.co.grib2'
 
 
 def test_aws_ls(aws_utils: AwsUtils, mock_exec_cmd):
     result = aws_utils.aws_ls(EXAMPLE_DIR)
 
     assert len(result) == len(EXAMPLE_FILES)
-    assert result[0] == f"{EXAMPLE_DIR}/{EXAMPLE_FILES[0]}"
+    assert result[0] == f'{EXAMPLE_DIR}/{EXAMPLE_FILES[0]}'
     mock_exec_cmd.assert_called_once()
 
 
@@ -93,8 +93,8 @@ def test_aws_ls_returns_empty_array_on_error(aws_utils: AwsUtils, monkeypatch: M
 
 
 def test_aws_cp_succeeds(aws_utils: AwsUtils, mock_exec_cmd):
-    path = f"{EXAMPLE_DIR}/file.grib2.idx"
-    dest = f"{EXAMPLE_DIR}/new_file.grib2.idx"
+    path = f'{EXAMPLE_DIR}/file.grib2.idx'
+    dest = f'{EXAMPLE_DIR}/new_file.grib2.idx'
 
     copy_success = aws_utils.aws_cp(path, dest)
     assert copy_success
@@ -153,7 +153,7 @@ def test_get_valids_all(aws_utils: AwsUtils, mock_exec_cmd):
     result = aws_utils.get_valids(EXAMPLE_ISSUE)
 
     assert len(result) == 2
-    assert result[1] == ((EXAMPLE_VALID + timedelta(hours=1)), f"{EXAMPLE_DIR}/{EXAMPLE_FILES[1]}")
+    assert result[1] == ((EXAMPLE_VALID + timedelta(hours=1)), f'{EXAMPLE_DIR}/{EXAMPLE_FILES[1]}')
 
 
 def test_get_valids_with_start_filter(aws_utils: AwsUtils, mock_exec_cmd):
@@ -161,7 +161,7 @@ def test_get_valids_with_start_filter(aws_utils: AwsUtils, mock_exec_cmd):
     result = aws_utils.get_valids(EXAMPLE_ISSUE, valid_start=valid_start)
 
     assert len(result) == 1
-    assert result[0] == (valid_start, f"{EXAMPLE_DIR}/{EXAMPLE_FILES[1]}")
+    assert result[0] == (valid_start, f'{EXAMPLE_DIR}/{EXAMPLE_FILES[1]}')
 
 
 def test_get_valids_with_start_and_end_filer(aws_utils: AwsUtils, mock_exec_cmd):
@@ -170,4 +170,4 @@ def test_get_valids_with_start_and_end_filer(aws_utils: AwsUtils, mock_exec_cmd)
     result = aws_utils.get_valids(EXAMPLE_ISSUE, valid_start=valid_start, valid_end=valid_end)
 
     assert len(result) == 1
-    assert result[0] == (valid_end, f"{EXAMPLE_DIR}/{EXAMPLE_FILES[0]}")
+    assert result[0] == (valid_end, f'{EXAMPLE_DIR}/{EXAMPLE_FILES[0]}')

--- a/python/idsse_common/test/test_aws_utils.py
+++ b/python/idsse_common/test/test_aws_utils.py
@@ -1,0 +1,173 @@
+"""Test suite for aws_utils.py"""
+# --------------------------------------------------------------------------------
+# Created on Wed Jun 21 2023
+#
+# Copyright (c) 2023 Colorado State University. All rights reserved.
+#
+# Contributors:
+#     Mackenzie Grimes
+#
+# --------------------------------------------------------------------------------
+
+import pytest  # pylint: disable=import-error
+from pytest import MonkeyPatch
+from unittest.mock import Mock
+
+from datetime import datetime, timedelta
+
+from idsse.common.aws_utils import AwsUtils
+
+# pylint: disable=missing-function-docstring
+# pylint: disable=invalid-name
+
+EXAMPLE_ISSUE = datetime(1970, 10, 3, 12)
+EXAMPLE_VALID = datetime(1970, 10, 3, 14)
+
+EXAMPLE_DIR = 's3://noaa-nbm-grib2-pds/blend.19701003/12/core'
+EXAMPLE_FILES = ['blend.t12z.core.f002.co.grib2',
+                 'blend.t13z.core.f002.co.grib2']
+
+# fixtures
+
+
+@pytest.fixture
+def aws_utils() -> AwsUtils:
+    EXAMPLE_BASE_DIR = 's3://noaa-nbm-grib2-pds/'
+    EXAMPLE_SUB_DIR = 'blend.{issue.year:04d}{issue.month:02d}{issue.day:02d}/{issue.hour:02d}/core/'
+    EXAMPLE_FILE_BASE = 'blend.t{issue.hour:02d}z.core.f{lead.hour:03d}'
+    EXAMPLE_FILE_EXT = '.co.grib2'
+
+    return AwsUtils(EXAMPLE_BASE_DIR, EXAMPLE_SUB_DIR, EXAMPLE_FILE_BASE, EXAMPLE_FILE_EXT)
+
+
+@pytest.fixture
+def mock_exec_cmd(monkeypatch: MonkeyPatch) -> Mock:
+    mock_function = Mock(return_value=EXAMPLE_FILES)
+    monkeypatch.setattr('idsse.common.aws_utils.exec_cmd', mock_function)
+    return mock_function
+
+# test class methods
+
+
+def test_get_path(aws_utils: AwsUtils):
+    result_path = aws_utils.get_path(EXAMPLE_ISSUE, EXAMPLE_VALID)
+    assert result_path == f"{EXAMPLE_DIR}/blend.t12z.core.f002.co.grib2"
+
+
+def test_aws_ls(aws_utils: AwsUtils, mock_exec_cmd):
+    result = aws_utils.aws_ls(EXAMPLE_DIR)
+
+    assert len(result) == len(EXAMPLE_FILES)
+    assert result[0] == f"{EXAMPLE_DIR}/{EXAMPLE_FILES[0]}"
+    mock_exec_cmd.assert_called_once()
+
+
+def test_aws_ls_without_prepend_path(aws_utils: AwsUtils, mock_exec_cmd):
+    result = aws_utils.aws_ls(EXAMPLE_DIR, prepend_path=False)
+
+    assert len(result) == len(EXAMPLE_FILES)
+    assert result[0] == EXAMPLE_FILES[0]
+    mock_exec_cmd.assert_called_once()
+
+
+def test_aws_ls_retries_with_s3_command_line(aws_utils: AwsUtils, monkeypatch: MonkeyPatch):
+    # fails first call, succeeds second call
+    mock_exec_cmd_failure = Mock(
+        side_effect=[FileNotFoundError, EXAMPLE_FILES])
+    monkeypatch.setattr('idsse.common.aws_utils.exec_cmd',
+                        mock_exec_cmd_failure)
+
+    result = aws_utils.aws_ls(EXAMPLE_DIR)
+    assert len(result) == 2  # ls should have eventually returned good data
+    assert mock_exec_cmd_failure.call_count == 2
+
+
+def test_aws_ls_returns_empty_array_on_error(aws_utils: AwsUtils, monkeypatch: MonkeyPatch):
+    mock_exec_cmd_failure = Mock(side_effect=PermissionError('No permissions'))
+    monkeypatch.setattr('idsse.common.aws_utils.exec_cmd',
+                        mock_exec_cmd_failure)
+
+    result = aws_utils.aws_ls(EXAMPLE_DIR)
+    assert result == []
+    mock_exec_cmd_failure.assert_called_once
+
+
+def test_aws_cp_succeeds(aws_utils: AwsUtils, mock_exec_cmd):
+    path = f"{EXAMPLE_DIR}/file.grib2.idx"
+    dest = f"{EXAMPLE_DIR}/new_file.grib2.idx"
+
+    copy_success = aws_utils.aws_cp(path, dest)
+    assert copy_success
+
+
+def test_aws_cp_retries_with_s3_command_line(aws_utils: AwsUtils, monkeypatch: MonkeyPatch):
+    mock_exec_cmd_failure = Mock(
+        side_effect=[FileNotFoundError, ['cp worked']])
+    monkeypatch.setattr('idsse.common.aws_utils.exec_cmd',
+                        mock_exec_cmd_failure)
+
+    copy_success = aws_utils.aws_cp('s3:/some/path', 's3:/new/path')
+    assert copy_success == True
+    assert mock_exec_cmd_failure.call_count == 2
+
+
+def test_aws_cp_fails(aws_utils: AwsUtils, monkeypatch: MonkeyPatch):
+    mock_exec_cmd_failure = Mock(
+        side_effect=[FileNotFoundError, Exception('unexpected bad thing happened')])
+    monkeypatch.setattr('idsse.common.aws_utils.exec_cmd',
+                        mock_exec_cmd_failure)
+
+    copy_success = aws_utils.aws_cp('s3:/some/path', 's3:/new/path')
+    assert copy_success == False
+    mock_exec_cmd_failure.call_count == 2
+
+
+def test_check_for_succeeds(aws_utils: AwsUtils, mock_exec_cmd):
+    result = aws_utils.check_for(EXAMPLE_ISSUE, EXAMPLE_VALID)
+    assert result is not None
+    assert result == (EXAMPLE_VALID, EXAMPLE_FILES[0])
+
+
+def test_check_for_does_not_find_valid(aws_utils: AwsUtils, mock_exec_cmd):
+    unexpected_valid = datetime(1970, 10, 3, 23)
+    result = aws_utils.check_for(EXAMPLE_ISSUE, unexpected_valid)
+    assert result is None
+
+
+def test_get_issues(aws_utils: AwsUtils, mock_exec_cmd):
+    result = aws_utils.get_issues(
+        issue_start=EXAMPLE_ISSUE, issue_end=EXAMPLE_VALID, num_issues=2)
+
+    assert len(result) == 2
+    assert result[0] == EXAMPLE_VALID - timedelta(hours=1)
+    assert result[1] == EXAMPLE_VALID - timedelta(hours=2)
+
+
+def test_get_issues_returns_latest_issue_from_today_if_no_args_passed(aws_utils: AwsUtils, mock_exec_cmd):
+    result = aws_utils.get_issues()
+    assert len(result) == 1
+    assert result[0].date() == datetime.now().date()
+
+
+def test_get_valids_all(aws_utils: AwsUtils, mock_exec_cmd):
+    result = aws_utils.get_valids(EXAMPLE_ISSUE)
+
+    assert len(result) == 2
+    assert result[1] == ((EXAMPLE_VALID + timedelta(hours=1)), f"{EXAMPLE_DIR}/{EXAMPLE_FILES[1]}")
+
+
+def test_get_valids_with_start_filter(aws_utils: AwsUtils, mock_exec_cmd):
+    valid_start = EXAMPLE_VALID + timedelta(hours=1)
+    result = aws_utils.get_valids(EXAMPLE_ISSUE, valid_start=valid_start)
+
+    assert len(result) == 1
+    assert result[0] == (valid_start, f"{EXAMPLE_DIR}/{EXAMPLE_FILES[1]}")
+
+
+def test_get_valids_with_start_and_end_filer(aws_utils: AwsUtils, mock_exec_cmd):
+    valid_start = EXAMPLE_VALID - timedelta(hours=1)
+    valid_end = EXAMPLE_VALID
+    result = aws_utils.get_valids(EXAMPLE_ISSUE, valid_start=valid_start, valid_end=valid_end)
+
+    assert len(result) == 1
+    assert result[0] == (valid_end, f"{EXAMPLE_DIR}/{EXAMPLE_FILES[0]}")

--- a/python/idsse_common/test/test_path_builder.py
+++ b/python/idsse_common/test/test_path_builder.py
@@ -1,0 +1,154 @@
+"""Test suite for path_builder.py"""
+# --------------------------------------------------------------------------------
+# Created on Thu Jun 15 2023
+#
+# Copyright (c) 2023 Colorado State University. All rights reserved.
+#
+# Contributors:
+#     Mackenzie Grimes
+#
+# --------------------------------------------------------------------------------
+
+import pytest  # pylint: disable=import-error
+from datetime import datetime, timedelta
+from typing import Union
+
+from idsse.common.utils import TimeDelta
+from idsse.common.path_builder import PathBuilder
+
+# pylint: disable=missing-function-docstring
+# pylint: disable=invalid-name
+
+def test_from_dir_filename_creates_valid_pathbuilder(): 
+    directory = "./test_directory"
+    filename ="some_file.txt"
+    path_builder = PathBuilder.from_dir_filename(directory, filename)
+
+    assert isinstance(path_builder, PathBuilder)
+    assert path_builder._basedir == directory
+    assert path_builder._file_ext == ""
+
+def test_from_path_creates_valid_pathbuilder():
+    base_dir = "./test_directory"
+    path_builder = PathBuilder.from_path(f"{base_dir}/some_file.txt")
+
+    assert isinstance(path_builder, PathBuilder)
+    assert path_builder._basedir == base_dir
+    assert path_builder._file_base == base_dir
+    assert path_builder._file_ext == ""
+
+# properties
+EXAMPLE_BASE_DIR = "./some/directory"
+EXAMPLE_SUB_DIR = "another/directory"
+EXAMPLE_FILE = "my_file"
+EXAMPLE_FILE_EXT = ".txt"
+
+@pytest.fixture
+def local_path_builder() -> PathBuilder:
+    # create example Pa†hBuilder instance using test strings
+    return PathBuilder(EXAMPLE_BASE_DIR, EXAMPLE_SUB_DIR, EXAMPLE_FILE, EXAMPLE_FILE_EXT)
+
+def test_dir_fmt(local_path_builder: PathBuilder):
+    assert local_path_builder.dir_fmt == f"{EXAMPLE_BASE_DIR}/{EXAMPLE_SUB_DIR}"
+
+def test_filename_fmt(local_path_builder: PathBuilder):
+    assert local_path_builder.filename_fmt == f"{EXAMPLE_FILE}{EXAMPLE_FILE_EXT}"
+
+def test_file_ext(local_path_builder: PathBuilder):
+    assert local_path_builder.file_ext == EXAMPLE_FILE_EXT
+
+def test_path_fmt(local_path_builder: PathBuilder):
+    assert local_path_builder.path_fmt == f"{EXAMPLE_BASE_DIR}/{EXAMPLE_SUB_DIR}/{EXAMPLE_FILE}{EXAMPLE_FILE_EXT}" 
+
+# methods
+EXAMPLE_ISSUE = datetime(1970, 10, 3, 12) # a.k.a. issued at
+EXAMPLE_VALID = datetime(1970, 10, 3, 14) # a.k.a. valid until
+EXAMPLE_LEAD = TimeDelta(EXAMPLE_VALID - EXAMPLE_ISSUE) # a.k.a. duration of time that issue lasts
+
+EXAMPLE_FULL_PATH = "~/blend.19701003/12/core/blend.t12z.core.f002.co.grib2.idx"
+
+@pytest.fixture
+def path_builder() -> PathBuilder:
+    subdirectory_pattern = "blend.{issue.year:04d}{issue.month:02d}{issue.day:02d}/{issue.hour:02d}/core/"
+    file_base_pattern = "blend.t{issue.hour:02d}z.core.f{lead.hour:03d}.co"
+    return PathBuilder("~", subdirectory_pattern, file_base_pattern, "grib2.idx")
+
+def test_build_dir_gets_issue_valid_and_lead(path_builder: PathBuilder):    
+    result_dict = path_builder.build_dir(issue=EXAMPLE_ISSUE)
+    assert result_dict == "~/blend.19701003/12/core/"
+
+def test_build_dir_fails_without_issue(path_builder: PathBuilder):
+    result_dict = path_builder.build_dir(issue=None)
+    assert result_dict is None
+
+def test_build_filename(path_builder: PathBuilder):
+    result_filename = path_builder.build_filename(issue=EXAMPLE_ISSUE, lead=EXAMPLE_LEAD)
+    assert result_filename == "blend.t12z.core.f002.co.grib2.idx"
+
+def test_build_path(path_builder: PathBuilder):
+    result_filepath = path_builder.build_path(issue=EXAMPLE_ISSUE, valid=EXAMPLE_VALID)
+    assert result_filepath == "~/blend.19701003/12/core/blend.t12z.core.f002.co.grib2.idx"
+
+def test_parse_dir(path_builder: PathBuilder):
+    result_dict = path_builder.parse_dir(EXAMPLE_FULL_PATH)
+
+    assert result_dict.keys() != []
+    assert result_dict["issue.year"] == 1970
+    assert result_dict["issue.day"] == 3
+
+def test_parse_filename(path_builder: PathBuilder):
+    result_dict = path_builder.parse_filename(EXAMPLE_FULL_PATH)
+    assert result_dict.keys() != []
+    assert result_dict["lead.hour"] == 2
+
+def test_get_issue(path_builder: PathBuilder):
+    actual_issue: datetime = path_builder.get_issue(EXAMPLE_FULL_PATH)
+    assert actual_issue == EXAMPLE_ISSUE
+
+def test_get_valid_from_issue_and_lead(path_builder: PathBuilder):
+    # verify valid timestamp gets successfully constructed based on issue and lead embedded into path
+    result_valid: datetime = path_builder.get_valid(EXAMPLE_FULL_PATH)
+    assert result_valid is not None
+    assert result_valid == EXAMPLE_VALID
+
+def test_get_valid_returns_none_when_issue_or_lead_failed(path_builder: PathBuilder):
+    path_with_invalid_lead = "~/blend.19701003/12/core/blend.t12z.core.f000.co.grib2.idx"
+    result_valid = path_builder.get_valid(path_with_invalid_lead)
+
+    assert result_valid is None
+
+# static methods
+def test_get_issue_from_time_args(path_builder: PathBuilder):
+    parsed_dict = path_builder.parse_path(EXAMPLE_FULL_PATH)
+    issue_result = PathBuilder.get_issue_from_time_args(parsed_args=parsed_dict)
+
+    assert issue_result == EXAMPLE_ISSUE
+
+def test_get_issue_returns_none_if_args_empty():
+    issue_result = PathBuilder.get_issue_from_time_args({})
+    assert issue_result is None
+
+def test_get_valid_from_time_args():
+    parsed_dict = {}
+    parsed_dict['valid.year'] = 1970
+    parsed_dict['valid.month'] = 10
+    parsed_dict['valid.day'] = 3
+    parsed_dict['valid.hour'] = 14
+
+    valid_result= PathBuilder.get_valid_from_time_args(parsed_dict)
+    assert valid_result == EXAMPLE_VALID
+
+def test_get_valid_returns_none_if_args_empty():
+    valid_result = PathBuilder.get_valid_from_time_args({})
+    assert valid_result is None
+
+def test_get_valid_from_time_args_calculates_based_on_lead(path_builder: PathBuilder):
+    parsed_dict = path_builder.parse_path(EXAMPLE_FULL_PATH)
+    result_valid: datetime = PathBuilder.get_valid_from_time_args(parsed_args=parsed_dict)
+  
+    assert result_valid == EXAMPLE_VALID
+
+def test_get_lead_from_time_args(path_builder: PathBuilder):
+    parsed_dict = path_builder.parse_path(EXAMPLE_FULL_PATH)
+    lead_result: timedelta = PathBuilder.get_lead_from_time_args(parsed_dict)
+    assert lead_result.seconds == EXAMPLE_LEAD.minute * 60

--- a/python/idsse_common/test/test_path_builder.py
+++ b/python/idsse_common/test/test_path_builder.py
@@ -20,28 +20,28 @@ from idsse.common.path_builder import PathBuilder
 # pylint: disable=invalid-name
 
 def test_from_dir_filename_creates_valid_pathbuilder(): 
-    directory = "./test_directory"
-    filename ="some_file.txt"
+    directory = './test_directory'
+    filename ='some_file.txt'
     path_builder = PathBuilder.from_dir_filename(directory, filename)
 
     assert isinstance(path_builder, PathBuilder)
     assert path_builder._basedir == directory
-    assert path_builder._file_ext == ""
+    assert path_builder._file_ext == ''
 
 def test_from_path_creates_valid_pathbuilder():
-    base_dir = "./test_directory"
-    path_builder = PathBuilder.from_path(f"{base_dir}/some_file.txt")
+    base_dir = './test_directory'
+    path_builder = PathBuilder.from_path(f'{base_dir}/some_file.txt')
 
     assert isinstance(path_builder, PathBuilder)
     assert path_builder._basedir == base_dir
     assert path_builder._file_base == base_dir
-    assert path_builder._file_ext == ""
+    assert path_builder._file_ext == ''
 
 # properties
-EXAMPLE_BASE_DIR = "./some/directory"
-EXAMPLE_SUB_DIR = "another/directory"
-EXAMPLE_FILE = "my_file"
-EXAMPLE_FILE_EXT = ".txt"
+EXAMPLE_BASE_DIR = './some/directory'
+EXAMPLE_SUB_DIR = 'another/directory'
+EXAMPLE_FILE = 'my_file'
+EXAMPLE_FILE_EXT = '.txt'
 
 @pytest.fixture
 def local_path_builder() -> PathBuilder:
@@ -49,33 +49,33 @@ def local_path_builder() -> PathBuilder:
     return PathBuilder(EXAMPLE_BASE_DIR, EXAMPLE_SUB_DIR, EXAMPLE_FILE, EXAMPLE_FILE_EXT)
 
 def test_dir_fmt(local_path_builder: PathBuilder):
-    assert local_path_builder.dir_fmt == f"{EXAMPLE_BASE_DIR}/{EXAMPLE_SUB_DIR}"
+    assert local_path_builder.dir_fmt == f'{EXAMPLE_BASE_DIR}/{EXAMPLE_SUB_DIR}'
 
 def test_filename_fmt(local_path_builder: PathBuilder):
-    assert local_path_builder.filename_fmt == f"{EXAMPLE_FILE}{EXAMPLE_FILE_EXT}"
+    assert local_path_builder.filename_fmt == f'{EXAMPLE_FILE}{EXAMPLE_FILE_EXT}'
 
 def test_file_ext(local_path_builder: PathBuilder):
     assert local_path_builder.file_ext == EXAMPLE_FILE_EXT
 
 def test_path_fmt(local_path_builder: PathBuilder):
-    assert local_path_builder.path_fmt == f"{EXAMPLE_BASE_DIR}/{EXAMPLE_SUB_DIR}/{EXAMPLE_FILE}{EXAMPLE_FILE_EXT}" 
+    assert local_path_builder.path_fmt == f'{EXAMPLE_BASE_DIR}/{EXAMPLE_SUB_DIR}/{EXAMPLE_FILE}{EXAMPLE_FILE_EXT}' 
 
 # methods
 EXAMPLE_ISSUE = datetime(1970, 10, 3, 12) # a.k.a. issued at
 EXAMPLE_VALID = datetime(1970, 10, 3, 14) # a.k.a. valid until
 EXAMPLE_LEAD = TimeDelta(EXAMPLE_VALID - EXAMPLE_ISSUE) # a.k.a. duration of time that issue lasts
 
-EXAMPLE_FULL_PATH = "~/blend.19701003/12/core/blend.t12z.core.f002.co.grib2.idx"
+EXAMPLE_FULL_PATH = '~/blend.19701003/12/core/blend.t12z.core.f002.co.grib2.idx'
 
 @pytest.fixture
 def path_builder() -> PathBuilder:
-    subdirectory_pattern = "blend.{issue.year:04d}{issue.month:02d}{issue.day:02d}/{issue.hour:02d}/core/"
-    file_base_pattern = "blend.t{issue.hour:02d}z.core.f{lead.hour:03d}.co"
-    return PathBuilder("~", subdirectory_pattern, file_base_pattern, "grib2.idx")
+    subdirectory_pattern = 'blend.{issue.year:04d}{issue.month:02d}{issue.day:02d}/{issue.hour:02d}/core/'
+    file_base_pattern = 'blend.t{issue.hour:02d}z.core.f{lead.hour:03d}.co'
+    return PathBuilder('~', subdirectory_pattern, file_base_pattern, 'grib2.idx')
 
 def test_build_dir_gets_issue_valid_and_lead(path_builder: PathBuilder):    
     result_dict = path_builder.build_dir(issue=EXAMPLE_ISSUE)
-    assert result_dict == "~/blend.19701003/12/core/"
+    assert result_dict == '~/blend.19701003/12/core/'
 
 def test_build_dir_fails_without_issue(path_builder: PathBuilder):
     result_dict = path_builder.build_dir(issue=None)
@@ -83,23 +83,23 @@ def test_build_dir_fails_without_issue(path_builder: PathBuilder):
 
 def test_build_filename(path_builder: PathBuilder):
     result_filename = path_builder.build_filename(issue=EXAMPLE_ISSUE, lead=EXAMPLE_LEAD)
-    assert result_filename == "blend.t12z.core.f002.co.grib2.idx"
+    assert result_filename == 'blend.t12z.core.f002.co.grib2.idx'
 
 def test_build_path(path_builder: PathBuilder):
     result_filepath = path_builder.build_path(issue=EXAMPLE_ISSUE, valid=EXAMPLE_VALID)
-    assert result_filepath == "~/blend.19701003/12/core/blend.t12z.core.f002.co.grib2.idx"
+    assert result_filepath == '~/blend.19701003/12/core/blend.t12z.core.f002.co.grib2.idx'
 
 def test_parse_dir(path_builder: PathBuilder):
     result_dict = path_builder.parse_dir(EXAMPLE_FULL_PATH)
 
     assert result_dict.keys() != []
-    assert result_dict["issue.year"] == 1970
-    assert result_dict["issue.day"] == 3
+    assert result_dict['issue.year'] == 1970
+    assert result_dict['issue.day'] == 3
 
 def test_parse_filename(path_builder: PathBuilder):
     result_dict = path_builder.parse_filename(EXAMPLE_FULL_PATH)
     assert result_dict.keys() != []
-    assert result_dict["lead.hour"] == 2
+    assert result_dict['lead.hour'] == 2
 
 def test_get_issue(path_builder: PathBuilder):
     actual_issue: datetime = path_builder.get_issue(EXAMPLE_FULL_PATH)
@@ -112,7 +112,7 @@ def test_get_valid_from_issue_and_lead(path_builder: PathBuilder):
     assert result_valid == EXAMPLE_VALID
 
 def test_get_valid_returns_none_when_issue_or_lead_failed(path_builder: PathBuilder):
-    path_with_invalid_lead = "~/blend.19701003/12/core/blend.t12z.core.f000.co.grib2.idx"
+    path_with_invalid_lead = '~/blend.19701003/12/core/blend.t12z.core.f000.co.grib2.idx'
     result_valid = path_builder.get_valid(path_with_invalid_lead)
 
     assert result_valid is None


### PR DESCRIPTION
## Features
- Add unit tests for `PathBuilder` and `AwsUtils` python classes with at least 80% code coverage
  - Made some minor changes to `PathBuilder` to handle error cases more gracefully, made apparent by inconsistent unit tests. 
  - E.g checking that `lead.hour` exists in arguments before attempting to build `lead` timedelta
  - Remove manual validation `_test()` functions that were serving the purpose of unit/regression tests
  
## Chores
- Add comments to PathBuilder explaining issue/valid/lead terminology
- Update readme with steps to generate pytest code coverage report

## Code Coverage
```
---------- coverage: platform darwin, python 3.11.4-final-0 ----------
Name                                               Stmts   Miss  Cover
----------------------------------------------------------------------
python/idsse_common/idsse/common/__init__.py           0      0   100%
python/idsse_common/idsse/common/aws_utils.py         77      5    94%
python/idsse_common/idsse/common/config.py           119     54    55%
python/idsse_common/idsse/common/path_builder.py     127     10    92%
python/idsse_common/idsse/common/utils.py             78     33    58%
python/idsse_common/setup.py                           2      2     0%
----------------------------------------------------------------------
TOTAL                                                403    104    74%

```