### PR TITLE
Chore: fix python type hints

### DIFF
--- a/python/idsse_common/idsse/common/aws_utils.py
+++ b/python/idsse_common/idsse/common/aws_utils.py
@@ -99,9 +99,9 @@ class AwsUtils():
             valid (datetime): The valid date/time used to format the path to the object's location
 
         Returns:
-            Tuple[datetime, str]: If object exists the valid date/time (indicated by object's
-                                  location) and the object's location (path) is returned as a tuple,
-                                  else the tuple(None, None) is returned
+            Optional[Tuple[datetime, str]]: A tuple of the valid date/time (indicated by object's 
+                                            location) and location (path) of a object, or None 
+                                            if object does not exist
         """
         lead = TimeDelta(valid-issue)
         filenames = self.aws_ls(self.get_path(issue, valid), prepend_path=False)
@@ -112,21 +112,21 @@ class AwsUtils():
         return None
 
     def get_issues(self,
-                   num_issues: Optional[int] = 1,
+                   num_issues: int = 1,
                    issue_start: Optional[datetime] = None,
                    issue_end: datetime = datetime.utcnow()
                    ) -> Sequence[datetime]:
         """Determine the available issue date/times
 
         Args:
-            num_issues (int, optional): Maximum number of issue to return. Defaults to 1.
+            num_issues (int): Maximum number of issue to return. Defaults to 1.
             issue_start (datetime, optional): The oldest date/time to look for. Defaults to None.
-            issue_end (datetime, optional): The newest date/time to look for. Defaults to None.
+            issue_end (datetime): The newest date/time to look for. Defaults to now (UTC).
 
         Returns:
-            Sequence[Tuple[datetime, str]]: A sequence of issue date/times
+            Sequence[datetime]: A sequence of issue date/times
         """
-        issues_found = []
+        issues_found: Sequence[datetime] = []
         if issue_start:
             datetimes = datetime_gen(issue_end, timedelta(hours=-1), issue_start, num_issues)
         else:
@@ -149,7 +149,7 @@ class AwsUtils():
     def get_valids(self,
                    issue: datetime,
                    valid_start: Optional[datetime] = None,
-                   valid_end: Optional[datetime] = None) -> Optional[Sequence[Tuple[datetime, str]]]:
+                   valid_end: Optional[datetime] = None) -> Sequence[Tuple[datetime, str]]:
         """Get all objects consistent with the passed issue date/time and filter by valid range
 
         Args:
@@ -161,11 +161,12 @@ class AwsUtils():
 
         Returns:
             Sequence[Tuple[datetime, str]]: A sequence of tuples with valid date/time (indicated by
-                                            object's location) and the object's location (path)
+                                            object's location) and the object's location (path). 
+                                            Empty Sequence if no valids found for given time range.
         """
         if valid_start and valid_start == valid_end:
             valids_and_filenames = self.check_for(issue, valid_start)
-            return [valids_and_filenames] if valids_and_filenames is not None else None
+            return [valids_and_filenames] if valids_and_filenames is not None else []
 
         dir_path = self.path_builder.build_dir(issue=issue)
 

--- a/python/idsse_common/idsse/common/aws_utils.py
+++ b/python/idsse_common/idsse/common/aws_utils.py
@@ -85,7 +85,7 @@ class AwsUtils():
                 commands = ['aws', 's3', '--no-sign-request',  'cp', path, dest]
                 exec_cmd(commands)
                 return True
-            except Exception:  # pytest: disable=broad-exception-caught
+            except Exception:  # pylint: disable=broad-exception-caught
                 return False
             finally:
                 pass

--- a/python/idsse_common/idsse/common/aws_utils.py
+++ b/python/idsse_common/idsse/common/aws_utils.py
@@ -11,8 +11,8 @@
 
 import logging
 import os
-from datetime import datetime, timedelta, timezone
-from typing import List, Tuple, Optional, Sequence
+from datetime import datetime, timedelta
+from typing import Sequence, Tuple, Optional
 
 from .path_builder import PathBuilder
 from .utils import TimeDelta, datetime_gen, exec_cmd
@@ -43,7 +43,7 @@ class AwsUtils():
         lead = TimeDelta(valid-issue)
         return self.path_builder.build_path(issue=issue, valid=valid, lead=lead)
 
-    def aws_ls(self, path: str, prepend_path: bool = True) -> List[str]:
+    def aws_ls(self, path: str, prepend_path: bool = True) -> Sequence[str]:
         """Execute an 'ls' on the AWS s3 bucket specified by path
 
         Args:

--- a/python/idsse_common/idsse/common/config.py
+++ b/python/idsse_common/idsse/common/config.py
@@ -49,7 +49,7 @@ class Config:
             filepaths = glob.glob(config, recursive=recursive)
             if len(filepaths) == 0:
                 raise FileNotFoundError
-            elif len(filepaths) == 1:
+            if len(filepaths) == 1:
                 self._from_filepath(filepaths[0], keys)
             else:
                 self._from_filepaths(filepaths, keys)

--- a/python/idsse_common/idsse/common/config.py
+++ b/python/idsse_common/idsse/common/config.py
@@ -13,7 +13,7 @@ import glob
 import json
 import logging
 from inspect import signature
-from typing import Self, Union, List
+from typing import Self, Union, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ class Config:
 
     def __init__(self,
                  config: Union[dict, List[dict], str],
-                 keys: Union[list, str] = None,
+                 keys: Optional[Union[list, str]] = None,
                  recursive: bool = False,
                  ignore_missing: bool = False) -> None:
 

--- a/python/idsse_common/idsse/common/log_util.py
+++ b/python/idsse_common/idsse/common/log_util.py
@@ -31,7 +31,7 @@ corr_id_context_var: ContextVar[str] = ContextVar('correlation_id')
 def set_corr_id_context_var(originator: str, key: uuid = None, issue_dt: Union[str, datetime] = None) -> None:
     if not key:
         key = uuid.uuid4()
-        
+
     if issue_dt:
         if not isinstance(issue_dt, str):
             issue_dt = to_iso(issue_dt)
@@ -72,7 +72,7 @@ def get_default_log_config(level, with_corr_id=True):
         format_str = '%(asctime)-15s %(name)-5s %(levelname)-8s %(corr_id)s %(module)s::%(funcName)s(line %(lineno)d) %(message)s'
     else:
         format_str = '%(asctime)-15s %(name)-5s %(levelname)-8s %(module)s::%(funcName)s(line %(lineno)d) %(message)s'
-        
+
     return {
     'version': 1,
     'disable_existing_loggers': False,

--- a/python/idsse_common/idsse/common/publish_confirm.py
+++ b/python/idsse_common/idsse/common/publish_confirm.py
@@ -6,9 +6,9 @@ import logging
 import logging.config
 import json
 import time
+from threading import Thread
 
 import pika
-from threading import Thread
 from pika.exchange_type import ExchangeType
 
 from idsse.common.log_util import get_default_log_config, set_corr_id_context_var

--- a/python/idsse_common/idsse/common/utils.py
+++ b/python/idsse_common/idsse/common/utils.py
@@ -13,7 +13,7 @@ import copy
 import logging
 from datetime import datetime, timedelta
 from subprocess import Popen, PIPE, TimeoutExpired
-from typing import Sequence
+from typing import Sequence, Optional, Generator, Any
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +70,7 @@ class Map(dict):
         del self.__dict__[key]
 
 
-def exec_cmd(commands: Sequence[str], timeout: int = None) -> Sequence[str]:
+def exec_cmd(commands: Sequence[str], timeout: Optional[int] = None) -> Sequence[str]:
     """Execute the passed commands via a Popen call
 
     Args:
@@ -145,8 +145,8 @@ def dict_copy_with(old_dict: dict, **kwargs) -> dict:
 
 def datetime_gen(dt_: datetime,
                  time_delta: timedelta,
-                 end_dt: datetime = None,
-                 max_num: int = 100) -> datetime:
+                 end_dt: Optional[datetime] = None,
+                 max_num: int = 100) -> Generator[datetime, Any, None]:
     """Create a date/time sequence generator, given a starting date/time and a time stride
 
     Args:

--- a/python/idsse_common/idsse/common/utils.py
+++ b/python/idsse_common/idsse/common/utils.py
@@ -96,8 +96,8 @@ def exec_cmd(commands: Sequence[str], timeout: Optional[int] = None) -> Sequence
         raise OSError(process.returncode, errs.decode())
     try:
         ans = outs.decode().splitlines()
-    except Exception as e:  # pylint: disable=broad-exception-caught
-        raise RuntimeError(e) from e
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        raise RuntimeError(exc) from exc
     return ans
 
 

--- a/python/idsse_common/test/test_aws_utils.py
+++ b/python/idsse_common/test/test_aws_utils.py
@@ -107,7 +107,7 @@ def test_aws_cp_retries_with_s3_command_line(aws_utils: AwsUtils, monkeypatch: M
                         mock_exec_cmd_failure)
 
     copy_success = aws_utils.aws_cp('s3:/some/path', 's3:/new/path')
-    assert copy_success == True
+    assert copy_success
     assert mock_exec_cmd_failure.call_count == 2
 
 
@@ -118,7 +118,7 @@ def test_aws_cp_fails(aws_utils: AwsUtils, monkeypatch: MonkeyPatch):
                         mock_exec_cmd_failure)
 
     copy_success = aws_utils.aws_cp('s3:/some/path', 's3:/new/path')
-    assert copy_success == False
+    assert not copy_success
     mock_exec_cmd_failure.call_count == 2
 
 
@@ -146,7 +146,7 @@ def test_get_issues(aws_utils: AwsUtils, mock_exec_cmd):
 def test_get_issues_returns_latest_issue_from_today_if_no_args_passed(aws_utils: AwsUtils, mock_exec_cmd):
     result = aws_utils.get_issues()
     assert len(result) == 1
-    assert result[0].date() == datetime.now().date()
+    assert result[0].date() == datetime.utcnow().date()
 
 
 def test_get_valids_all(aws_utils: AwsUtils, mock_exec_cmd):


### PR DESCRIPTION
Correct some python type hint decorators which didn't match the actual runtime variables returned from functions in `aws_utils.py` and `utils.py`. 
- For example, functions that return a `Sequence`, or sometimes `None` on error, were annotated to always return a `Sequence`. 
- Or a function parameter which default to `None` was typed as non-null, so linters would complain if you omitted the parameter but the code would execute without issue.