### PR TITLE
Bug: log util errors without correlation ID

### DIFF
--- a/python/idsse_common/idsse/common/log_util.py
+++ b/python/idsse_common/idsse/common/log_util.py
@@ -30,9 +30,9 @@ def set_corr_id_context_var(
     issue_dt: Optional[Union[str, datetime]] = None
 ) -> None:
     """
-    Build and set correlation ID ContextVar for logging module, based on originator and 
+    Build and set correlation ID ContextVar for logging module, based on originator and
     key (or generated UUID). Include issue_dt in correlation ID if provided.
-    
+
     Args:
         originator (str): Function, class, service name, etc. that is using logging module
         key (Optional[uuid.UUID]): a UUID. Default: randomly generated UUID.
@@ -79,16 +79,16 @@ class UTCFormatter(logging.Formatter):
 
 def get_default_log_config(level: str, with_corr_id=True):
     """
-    Get standardized python logging config (formatters, handlers directing to stdout, etc.) 
+    Get standardized python logging config (formatters, handlers directing to stdout, etc.)
     as a dictionary. This dictionary can be passed directly to logging.config.dictConfig:
-    
+
     import logging
     import logging.config
-    
+
     logging.config.dictConfig(get_default_log_config('INFO'))
     logger = logging.getLogger(__name__)
     logger.info('hello world')
-    
+
     Args:
         level (str): logging level, such as 'DEBUG'
         with_corr_id (bool): whether to include correlation ID in log messages. Default: True

--- a/python/idsse_common/idsse/common/log_util.py
+++ b/python/idsse_common/idsse/common/log_util.py
@@ -8,6 +8,7 @@
 #     Geary Layne
 #
 # ------------------------------------------------------------------------------
+# pylint: disable=too-few-public-methods
 
 import logging
 import time
@@ -28,6 +29,15 @@ def set_corr_id_context_var(
     key: Optional[uuid.UUID] = None,
     issue_dt: Optional[Union[str, datetime]] = None
 ) -> None:
+    """
+    Build and set correlation ID ContextVar for logging module, based on originator and 
+    key (or generated UUID). Include issue_dt in correlation ID if provided.
+    
+    Args:
+        originator (str): Function, class, service name, etc. that is using logging module
+        key (Optional[uuid.UUID]): a UUID. Default: randomly generated UUID.
+        issue_dt (Optional[Union[str, datettime]]): Datetime when a relevant forecast was issued
+    """
     if not key:
         key = uuid.uuid4()
 
@@ -40,10 +50,12 @@ def set_corr_id_context_var(
 
 
 def get_corr_id_context_var_str():
+    """Getter for correlation ID ContextVar name"""
     return corr_id_context_var.get()
 
 def get_corr_id_context_var_parts():
-    return tuple([part for part in corr_id_context_var.get().split(';')])
+    """Split correlation ID ContextVar into its parts, such as [originator, key, issue_datetime]"""
+    return corr_id_context_var.get().split(';')
 
 class AddCorrelationIdFilter(logging.Filter):
     """"Provides correlation id parameter for the logger"""
@@ -65,7 +77,22 @@ class UTCFormatter(logging.Formatter):
     converter = time.gmtime
 
 
-def get_default_log_config(level, with_corr_id=True):
+def get_default_log_config(level: str, with_corr_id=True):
+    """
+    Get standardized python logging config (formatters, handlers directing to stdout, etc.) 
+    as a dictionary. This dictionary can be passed directly to logging.config.dictConfig:
+    
+    import logging
+    import logging.config
+    
+    logging.config.dictConfig(get_default_log_config('INFO'))
+    logger = logging.getLogger(__name__)
+    logger.info('hello world')
+    
+    Args:
+        level (str): logging level, such as 'DEBUG'
+        with_corr_id (bool): whether to include correlation ID in log messages. Default: True
+    """
     set_corr_id_context_var('None', uuid.UUID('00000000-0000-0000-0000-000000000000'))
     if with_corr_id:
         format_str = (

--- a/python/idsse_common/idsse/common/log_util.py
+++ b/python/idsse_common/idsse/common/log_util.py
@@ -14,21 +14,20 @@ import time
 import uuid
 from contextvars import ContextVar
 from datetime import datetime
-from typing import Union
+from typing import Union, Optional
 
 from .utils import to_iso
 
-# flake8: noqa E501
-# pylint: disable=line-too-long
 # cSpell:words gmtime
 
-# correlation_id: ContextVar[uuid.UUID] = \
-#     ContextVar('correlation_id',
-#                default=uuid.UUID('00000000-0000-0000-0000-000000000000'))
 corr_id_context_var: ContextVar[str] = ContextVar('correlation_id')
 
 
-def set_corr_id_context_var(originator: str, key: uuid = None, issue_dt: Union[str, datetime] = None) -> None:
+def set_corr_id_context_var(
+    originator: str,
+    key: Optional[uuid.UUID] = None,
+    issue_dt: Optional[Union[str, datetime]] = None
+) -> None:
     if not key:
         key = uuid.uuid4()
 
@@ -69,10 +68,16 @@ class UTCFormatter(logging.Formatter):
 def get_default_log_config(level, with_corr_id=True):
     set_corr_id_context_var('None', uuid.UUID('00000000-0000-0000-0000-000000000000'))
     if with_corr_id:
-        format_str = '%(asctime)-15s %(name)-5s %(levelname)-8s %(corr_id)s %(module)s::%(funcName)s(line %(lineno)d) %(message)s'
+        format_str = (
+            '%(asctime)-15s %(name)-5s %(levelname)-8s %(corr_id)s %(module)s::'
+            '%(funcName)s"(line %(lineno)d) %(message)s'
+        )
         filter_list = ['corr_id', ]
     else:
-        format_str = '%(asctime)-15s %(name)-5s %(levelname)-8s %(module)s::%(funcName)s(line %(lineno)d) %(message)s'
+        format_str = (
+            '%(asctime)-15s %(name)-5s %(levelname)-8s %(module)s::'
+            '%(funcName)s(line %(lineno)d) %(message)s'
+        )
         filter_list = []
 
     return {

--- a/python/idsse_common/idsse/common/log_util.py
+++ b/python/idsse_common/idsse/common/log_util.py
@@ -70,8 +70,10 @@ def get_default_log_config(level, with_corr_id=True):
     set_corr_id_context_var('None', uuid.UUID('00000000-0000-0000-0000-000000000000'))
     if with_corr_id:
         format_str = '%(asctime)-15s %(name)-5s %(levelname)-8s %(corr_id)s %(module)s::%(funcName)s(line %(lineno)d) %(message)s'
+        filter_list = ['corr_id', ]
     else:
         format_str = '%(asctime)-15s %(name)-5s %(levelname)-8s %(module)s::%(funcName)s(line %(lineno)d) %(message)s'
+        filter_list = []
 
     return {
     'version': 1,
@@ -92,7 +94,7 @@ def get_default_log_config(level, with_corr_id=True):
             'class': 'logging.StreamHandler',
             'stream': 'ext://sys.stdout',
             'formatter': 'standard',
-            'filters': ['corr_id', ],
+            'filters': filter_list,
         },
     },
     'loggers': {

--- a/python/idsse_common/idsse/common/log_util.py
+++ b/python/idsse_common/idsse/common/log_util.py
@@ -2,10 +2,12 @@
 # ------------------------------------------------------------------------------
 # Created on Thu Apr 27 2023
 #
-# Copyright (c) 2023 Regents of the University of Colorado. All rights reserved.
+# Copyright (c) 2023 Regents of the University of Colorado. All rights reserved. (1)
+# Copyright (c) 2023 Colorado State University. All rights reserved. (2)
 #
 # Contributors:
-#     Geary Layne
+#     Geary Layne (1)
+#     Mackenzie Grimes (2)
 #
 # ------------------------------------------------------------------------------
 # pylint: disable=too-few-public-methods

--- a/python/idsse_common/idsse/common/publish_confirm.py
+++ b/python/idsse_common/idsse/common/publish_confirm.py
@@ -319,7 +319,7 @@ class PublishConfirm(Thread):
 def main():
 
     # Connect to localhost:5672 as guest with the password guest and virtual host "/" (%2F)
-    expub = PublishConfirm(
+    expub = EventPublisher(
         'amqp://guest:guest@localhost:5672/%2F?connection_attempts=3&heartbeat=3600',
         'data.available', '_data.check'
     )

--- a/python/idsse_common/idsse/common/publish_confirm.py
+++ b/python/idsse_common/idsse/common/publish_confirm.py
@@ -319,7 +319,7 @@ class PublishConfirm(Thread):
 def main():
 
     # Connect to localhost:5672 as guest with the password guest and virtual host "/" (%2F)
-    expub = EventPublisher(
+    expub = PublishConfirm(
         'amqp://guest:guest@localhost:5672/%2F?connection_attempts=3&heartbeat=3600',
         'data.available', '_data.check'
     )


### PR DESCRIPTION
## Linear Task
N/A

## Background
Calling `get_default_log_config()` with `with_corr_id=False` was still expecting a `corr_id` to exist in the filters that it passed to logging.config.

This would cause the following exception to be thrown as soon as the caller class attempted to use their logger:
```sh
Traceback (most recent call last):
    File "lib/python3.11/logging/__init__.py", line 974, in handle
      rv = self.filter(record)
           ^^^^^^^^^^^^^^^^^^^
    File "lib/python3.11/logging/__init__.py", line 830, in filter
      result = f.filter(record)
               ^^^^^^^^^^^^^^^^
    File "idss-engine-commons/python/idsse_common/idsse/common/log_util.py", line 52, in filter
      record.corr_id = corr_id_context_var.get()
LookupError: <ContextVar name='correlation_id' at 0x104b40db0>
```

## Changes
- `filters:` in logging config only has `corr_id` if it's also in the logger format string
- Code formatting and docstrings to make pylint happy