### PR TITLE
Small cleanup

### DIFF
--- a/python/idsse_common/idsse/common/aws_utils.py
+++ b/python/idsse_common/idsse/common/aws_utils.py
@@ -107,7 +107,8 @@ class AwsUtils():
         filenames = self.aws_ls(self.get_path(issue, valid), prepend_path=False)
         filename = self.path_builder.build_filename(issue=issue, valid=valid, lead=lead)
         for fname in filenames:
-            # Support wildcard matches - used for '?' as a single wildcard character in issue/valid time specs.
+            # Support wildcard matches - used for '?' as a single wildcard character in
+            # issue/valid time specs.
             if fnmatch.fnmatch(os.path.basename(fname), filename):
                 return (valid, filename)
         return None

--- a/python/idsse_common/idsse/common/log_util.py
+++ b/python/idsse_common/idsse/common/log_util.py
@@ -55,15 +55,18 @@ def get_corr_id_context_var_str():
     """Getter for correlation ID ContextVar name"""
     return corr_id_context_var.get()
 
+
 def get_corr_id_context_var_parts():
     """Split correlation ID ContextVar into its parts, such as [originator, key, issue_datetime]"""
     return corr_id_context_var.get().split(';')
+
 
 class AddCorrelationIdFilter(logging.Filter):
     """"Provides correlation id parameter for the logger"""
     def filter(self, record):
         record.corr_id = corr_id_context_var.get()
         return True
+
 
 class CorrIdFilter(logging.Filter):
     """"Provides correlation id parameter for the logger"""
@@ -73,6 +76,7 @@ class CorrIdFilter(logging.Filter):
 
     def filter(self, record):
         return not hasattr(record, 'correlation_id') or self._corr_id == record.corr_id
+
 
 class UTCFormatter(logging.Formatter):
     """"Provides a callable time format converter for the logging"""
@@ -110,31 +114,31 @@ def get_default_log_config(level: str, with_corr_id=True):
         filter_list = []
 
     return {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'formatters': {
-        'standard': {
-            '()': UTCFormatter,
-            'format': format_str
+        'version': 1,
+        'disable_existing_loggers': False,
+        'formatters': {
+            'standard': {
+                '()': UTCFormatter,
+                'format': format_str
+            },
         },
-    },
-    'filters': {
-        'corr_id': {
-            '()': AddCorrelationIdFilter,
+        'filters': {
+            'corr_id': {
+                '()': AddCorrelationIdFilter,
+            },
         },
-    },
-    'handlers': {
-        'default': {
-            'class': 'logging.StreamHandler',
-            'stream': 'ext://sys.stdout',
-            'formatter': 'standard',
-            'filters': filter_list,
+        'handlers': {
+            'default': {
+                'class': 'logging.StreamHandler',
+                'stream': 'ext://sys.stdout',
+                'formatter': 'standard',
+                'filters': filter_list,
+            },
         },
-    },
-    'loggers': {
-        '': {
-            'level': level,
-            'handlers': ['default', ],
-        },
+        'loggers': {
+            '': {
+                'level': level,
+                'handlers': ['default', ],
+            },
+        }
     }
-}

--- a/python/idsse_common/idsse/common/utils.py
+++ b/python/idsse_common/idsse/common/utils.py
@@ -178,6 +178,7 @@ def _round_away_from_zero(number: float) -> int:
     func = math.floor if number < 0 else math.ceil
     return func(number)
 
+
 def _round_toward_zero(number: float) -> int:
     func = math.ceil if number < 0 else math.floor
     return func(number)
@@ -236,15 +237,17 @@ def shrink_grib(filename: str, variables: List[str]) -> None:
     req_vars = set(variables)
     try:
         # Open a work file for the result..
-        with open(f'{filename}{".tmp"}', 'wb') as grb_out:
+        tmp_filename = f'{filename}.tmp'
+        with open(tmp_filename, 'wb') as grb_out:
             # Open the GRIB file
             with pygrib.open(filename) as grb:  # pylint: disable=no-member
-                for g in grb:
-                    if g.name in req_vars or f'parameterNumber: {str(g.parameterNumber)}' in req_vars:
-                        grb_out.write(g.tostring())
+                for grb_record in grb:
+                    if grb_record.name in req_vars or \
+                       f'parameterNumber: {str(grb_record.parameterNumber)}' in req_vars:
+                        grb_out.write(grb_record.tostring())
             # Close the out file and clobber the original
             grb_out.close()
-            shutil.move(f'{filename}.tmp', filename)
+            shutil.move(tmp_filename, filename)
 
     # Create a set from the variable list...
     except Exception as exc:  # pylint: disable=broad-exception-caught


### PR DESCRIPTION
While working on Linear 348 (benchmarking converting vector to raster) can across an indentation error and some other small linter issues. 

There are a couple of lines that were more than 100 char long, which I split onto two lines. I don't think we have formally addressed line length, but my take on it is: We can allow up to 120, but should try to keep them at 100. I have two reasons for this, 1) there has been studies that show line length up to 99 are easily readable but after that there is impact, and 2) with my screen resolution, font size, and window size, It gets harder when lines are over 100, often I have to scroll left/right.