### PR TITLE
Add optional Queue parameters to PublishConfirm

### DIFF
--- a/python/idsse_common/idsse/common/publish_confirm.py
+++ b/python/idsse_common/idsse/common/publish_confirm.py
@@ -271,7 +271,7 @@ class PublishConfirm(Thread):
             '%i were acked and %i were nacked', self._message_number,
             len(self._deliveries), self._acked, self._nacked)
 
-    def publish_message(self, message, key='#'):
+    def publish_message(self, message, key=''):
         """If the class is not stopping, publish a message to RabbitMQ,
         appending a list of deliveries with the message number that was sent.
         This list will be used to check for delivery confirmations in the

--- a/python/idsse_common/idsse/common/publish_confirm.py
+++ b/python/idsse_common/idsse/common/publish_confirm.py
@@ -42,7 +42,7 @@ class PublishConfirm(Thread):
         to connect to RabbitMQ.
         :param str url: The URL connecting to RabbitMQ
         :param str exchange: The RabbitMQ exchange on which to publish
-        :param str queue: The RabbitMQ default queue
+        :param str queue: The RabbitMQ default queue name
         :param Queue queue_params: Optional parameters to control how RabbitMQ queue is declared
         """
         Thread.__init__(self, daemon=True)

--- a/python/idsse_common/idsse/common/publish_confirm.py
+++ b/python/idsse_common/idsse/common/publish_confirm.py
@@ -297,7 +297,7 @@ class PublishConfirm(Thread):
     def run(self):
         """Run the thread, i.e. get connection etc...
         """
-        logging.config.dictConfig(get_default_log_config('INFO', False))
+        logging.config.dictConfig(get_default_log_config('INFO'))
 
         self._connection = self.connect()
         self._connection.ioloop.start()


### PR DESCRIPTION
## Changes
- Add optional argument `queue_params` to PublishConfirm
- If this argument is not None, use its attributes (exclusive, durable, auto_delete) when we are declaring the RabbitMQ queue to connect to

Note: The existing `queue` string argument is still supported, so this should not break any existing usage of PublishConfirm.

### Other changes
- Minor type hints from `pika` library
- Default `key` argument in `publish_message()` to empty string, not None
  - Previously, allowing it to default to `None` caused a RabbitMQ error "A non-string value was supplied for self.routing_key"

## Reason
This change was needed to connect to an existing RabbitMQ queue that was declared with anything other than the default queue parameters.

For example, if the queue was previously created with `durable` enabled, it may already exist in the RabbitMQ server, and attempting to connect to it and publish without passing `durable=True` would throw an error:
```
idsse.common.publish_confirm INFO     None;00000000-0000-0000-0000-000000000000;_ \
    publish_confirm::setup_queue"(line 182) Declaring queue my_queue

pika.channel WARNING    None;00000000-0000-0000-0000-000000000000;_ \
    Received remote Channel.Close (406): "PRECONDITION_FAILED - inequivalent arg 'durable' \
    for queue my_queue in vhost '/': received 'false' but current is 'true'"

pika.adapters.utils.io_services_utils INFO     None;00000000-0000-0000-0000-000000000000;_ \
    io_services_utils::abort"(line 731) Aborting transport connection: state=1; \
    <socket.socket fd=10, family=2, type=1, proto=6, laddr=('127.0.0.1', 58003), raddr=('127.0.0.1', 5672)>
```