### PR TITLE
Chore: fix pytest runner coverage

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,7 @@ jobs:
           channels: conda-forge
 
       - name: Install dependencies with conda
-        run: conda install pytest pylint==2.17.5 python-dateutil==2.8.2 pint==0.21 importlib-metadata==6.7.0 jsonschema==4.19.0 pika=1.3.1 pyproj pygrib=2.1.4
+        run: conda install pytest pytest-cov pylint==2.17.5 python-dateutil==2.8.2 pint==0.21 importlib-metadata==6.7.0 jsonschema==4.19.0 pika=1.3.1 pyproj pygrib=2.1.4
 
       - name: Set PYTHONPATH for pytest
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,7 +22,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-cov pylint==2.17.5 python-dateutil==2.8.2 pint==0.21 importlib-metadata==6.7.0 jsonschema==4.19.0 pika==1.3.1 pyproj pygrib==2.1.4
+          pip install pytest pytest-cov pylint==2.17.5 python-dateutil==2.8.2 pint==0.21 importlib-metadata==6.7.0 jsonschema==4.19.0 pika==1.3.1 pyproj
+          pip install eccodes==1.6.0
+          export ECCODES_DIR="$( pip show eccodes | grep "Location" | cut -d ' ' -f 2 )/eccodes"
+          pip install pygrib=2.1.4
       #- name: Install conda env
       #  uses: conda-incubator/setup-miniconda@v2
       #  with:
@@ -44,7 +47,7 @@ jobs:
         with:
           hide-comment: true
           pytest-coverage-path: python/idsse_common/test/coverage.txt
-      
+
       - name: Update Readme with Coverage Html
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,30 +15,24 @@ jobs:
         python-version: [ "3.11" ]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+      - name: Install conda env
+        uses: conda-incubator/setup-miniconda@v2
         with:
+          auto-update-conda: true
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+          channels: conda-forge
+
+      - name: Install dependencies with conda
+        run: conda install pytest pylint==2.17.5 python-dateutil==2.8.2 pint==0.21 importlib-metadata==6.7.0 jsonschema==4.19.0 pika=1.3.1 pyproj pygrib=2.1.4
+
+      - name: Set PYTHONPATH for pytest
         run: |
-          python -m pip install --upgrade pip
-          pip install pytest pytest-cov pylint==2.17.5 python-dateutil==2.8.2 pint==0.21 importlib-metadata==6.7.0 jsonschema==4.19.0 pika==1.3.1 pyproj
-          pip install eccodes==1.6.0
-          export ECCODES_DIR="$( pip show eccodes | grep "Location" | cut -d ' ' -f 2 )/eccodes"
-          pip install pygrib=2.1.4
-      #- name: Install conda env
-      #  uses: conda-incubator/setup-miniconda@v2
-      #  with:
-      #    auto-update-conda: true
-      #    python-version: ${{ matrix.python-version }}
-      #    channels: conda-forge
-      #- name: Install dependencies with conda
-      #  run: |
-      #    conda install pytest python-dateutil==2.8.2 pint==0.21
+          echo "PYTHONPATH=python/idsse_common/idsse/common" >> $GITHUB_ENV
+
       - name: Test with pytest
-        working-directory: python/idsse_common/test
+        working-directory: python/idsse_common
         run: |
-          pytest --cov=../idsse/common --cov-report=term --junitxml=./pytest.xml | tee ./coverage.txt
+          pytest ./test --cov=./idsse/common --cov-report=term --junitxml=./pytest.xml | tee ./coverage.txt
 
       - name: Pytest coverage comment
         if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
## Linear Issue
N/A

## Changes
- Update pytest GitHub Actions workflow to install all dependencies with conda
  - Missing dependency `pygrib` was causing test coverage to be artificially low, but attempting to install pygrib with `pip` threw errors, causing tests to fail
 

We can revert this change (use pip to install dependencies again) after [IDSSE-352](https://linear.app/idss/issue/IDSSE-352) is completed (refactor `shrink_grib()` util into Data Access Service)