### PR TITLE
JSON Schema for AvailableData Request

### DIFF
--- a/python/idsse_common/test/test_validate_schema.py
+++ b/python/idsse_common/test/test_validate_schema.py
@@ -246,7 +246,9 @@ def test_validate_das_criteria_join_request():
                     "thresh": 3},
                 "label": "NBM:WINDSPEED:MilesPerHour:GT:3.000:0.000:5.000:true"}],
             "join": "AND"},
-        "label": "AND(NBM:TEMP:Fahrenheit:LT:60.000:35.000:75.000:true, NBM:WINDSPEED:MilesPerHour:GT:3.000:0.000:5.000:true)"}  # noqa: E501
+        "label": ("AND(NBM:TEMP:Fahrenheit:LT:60.000:35.000:75.000:true, "
+                  "NBM:WINDSPEED:MilesPerHour:GT:3.000:0.000:5.000:true)")
+    }
 
     schema_name = 'das_request_schema'
     validator = get_validator(schema_name)

--- a/python/idsse_common/test/test_validate_schema.py
+++ b/python/idsse_common/test/test_validate_schema.py
@@ -8,17 +8,13 @@
 #     Geary Layne (1)
 #
 # ----------------------------------------------------------------------------------
-# pylint: disable=missing-function-docstring,redefined-outer-name,invalid-name
-
-from jsonschema.exceptions import ValidationError
-import pytest
-from pytest import fixture
+# pylint: disable=missing-function-docstring,redefined-outer-name,invalid-name,no-name-in-module
 
 from jsonschema import Validator
+from jsonschema.exceptions import ValidationError
+from pytest import fixture, raises
 
 from idsse.common.validate_schema import get_validator
-
-# pylint: disable=missing-function-docstring, line-too-long
 
 
 @fixture
@@ -46,7 +42,7 @@ def test_validate_das_bad_issue_request(available_data_validator: Validator):
                              'field': 'TEMP',
                              'valid': '2022-01-02T15:00:00.000Z'
                              }}
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         available_data_validator.validate(message)
 
 
@@ -70,7 +66,7 @@ def test_validate_das_bad_valid_request(available_data_validator: Validator):
                              'region': 'PR',
                              'issue': '2022-01-02T12:00:00.000Z'
                              }}
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         available_data_validator.validate(message)
 
 
@@ -94,7 +90,7 @@ def test_validate_das_bad_lead_request(available_data_validator: Validator):
                              'field': 'TEMP',
                              'issue': '2022-01-02T12:00:00.000Z'
                              }}
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         available_data_validator.validate(message)
 
 
@@ -120,7 +116,7 @@ def test_validate_das_bad_field_request(available_data_validator: Validator):
                              'field': 'TEMP',
                              'valid': '2022-01-02T15:00:00.000Z'
                              }}
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         available_data_validator.validate(message)
 
 
@@ -293,7 +289,7 @@ def test_validate_bad_criteria_message():
     schema_name = 'criteria_schema'
     validator = get_validator(schema_name)
 
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         validator.validate(message)
 
 

--- a/python/idsse_common/test/test_validate_schema.py
+++ b/python/idsse_common/test/test_validate_schema.py
@@ -8,29 +8,120 @@
 #     Geary Layne (1)
 #
 # ----------------------------------------------------------------------------------
+# pylint: disable=missing-function-docstring,redefined-outer-name,invalid-name
 
 from jsonschema.exceptions import ValidationError
 import pytest
+from pytest import fixture
+
+from jsonschema import Validator
 
 from idsse.common.validate_schema import get_validator
 
 # pylint: disable=missing-function-docstring, line-too-long
 
 
-def test_validate_das_valid_request():
+@fixture
+def available_data_validator() -> Validator:
+    schema_name = 'das_available_data_schema'
+    return get_validator(schema_name)
+
+
+def test_validate_das_issue_request(available_data_validator: Validator):
+    message = {'sourceType': 'issue',
+               'sourceObj': {'product': 'NBM.AWS.GRIB',
+                             'region': 'PR',
+                             'field': 'TEMP',
+                             }}
+    try:
+        available_data_validator.validate(message)
+    except ValidationError as exc:
+        assert False, f'Validate message raised an exception {exc}'
+
+
+def test_validate_das_bad_issue_request(available_data_validator: Validator):
+    # message is missing 'region'
+    message = {'sourceType': 'field',
+               'sourceObj': {'product': 'NBM.AWS.GRIB',
+                             'field': 'TEMP',
+                             'valid': '2022-01-02T15:00:00.000Z'
+                             }}
+    with pytest.raises(ValidationError):
+        available_data_validator.validate(message)
+
+
+def test_validate_das_valid_request(available_data_validator: Validator):
     message = {'sourceType': 'valid',
                'sourceObj': {'product': 'NBM.AWS.GRIB',
                              'region': 'PR',
                              'field': 'TEMP',
                              'issue': '2022-01-02T12:00:00.000Z'
                              }}
-
-    schema_name = 'das_available_data_schema'
-    validator = get_validator(schema_name)
     try:
-        validator.validate(message)
+        available_data_validator.validate(message)
     except ValidationError as exc:
         assert False, f'Validate message raised an exception {exc}'
+
+
+def test_validate_das_bad_valid_request(available_data_validator: Validator):
+    # message is missing 'field'
+    message = {'sourceType': 'valid',
+               'sourceObj': {'product': 'NBM.AWS.GRIB',
+                             'region': 'PR',
+                             'issue': '2022-01-02T12:00:00.000Z'
+                             }}
+    with pytest.raises(ValidationError):
+        available_data_validator.validate(message)
+
+
+def test_validate_das_lead_request(available_data_validator: Validator):
+    message = {'sourceType': 'lead',
+               'sourceObj': {'product': 'NBM.AWS.GRIB',
+                             'region': 'PR',
+                             'field': 'TEMP',
+                             'issue': '2022-01-02T12:00:00.000Z'
+                             }}
+    try:
+        available_data_validator.validate(message)
+    except ValidationError as exc:
+        assert False, f'Validate message raised an exception {exc}'
+
+
+def test_validate_das_bad_lead_request(available_data_validator: Validator):
+    # message is missing 'product'
+    message = {'sourceType': 'valid',
+               'sourceObj': {'region': 'PR',
+                             'field': 'TEMP',
+                             'issue': '2022-01-02T12:00:00.000Z'
+                             }}
+    with pytest.raises(ValidationError):
+        available_data_validator.validate(message)
+
+
+def test_validate_das_field_request(available_data_validator: Validator):
+    message = {'sourceType': 'field',
+               'sourceObj': {'product': 'NBM.AWS.GRIB',
+                             'region': 'PR',
+                             'field': 'TEMP',
+                             'issue': '2022-01-02T12:00:00.000Z',
+                             'valid': '2022-01-02T15:00:00.000Z'
+                             }}
+    try:
+        available_data_validator.validate(message)
+    except ValidationError as exc:
+        assert False, f'Validate message raised an exception {exc}'
+
+
+def test_validate_das_bad_field_request(available_data_validator: Validator):
+    # message is missing 'issue'
+    message = {'sourceType': 'field',
+               'sourceObj': {'product': 'NBM.AWS.GRIB',
+                             'region': 'PR',
+                             'field': 'TEMP',
+                             'valid': '2022-01-02T15:00:00.000Z'
+                             }}
+    with pytest.raises(ValidationError):
+        available_data_validator.validate(message)
 
 
 def test_validate_das_data_request():


### PR DESCRIPTION
Linear 335

The task was to write and test a schema that can be used to validate AvailableData requests. The schema was already written so I simply added the tests. There are four types of AvailableData request, request for issue(s), valid(s), lead(s), field(s).