### PR TITLE
Bug: publish_confirm error "message_number is read-only"

### DIFF
--- a/python/idsse_common/idsse/common/publish_confirm.py
+++ b/python/idsse_common/idsse/common/publish_confirm.py
@@ -16,8 +16,9 @@ import logging
 import logging.config
 import json
 import time
+from dataclasses import dataclass, field
 from threading import Thread
-from typing import NamedTuple, Optional, Dict
+from typing import Optional, Dict
 
 import pika
 from pika import SelectConnection
@@ -29,7 +30,8 @@ from idsse.common.log_util import get_default_log_config, set_corr_id_context_va
 logger = logging.getLogger(__name__)
 
 
-class PublishedMessages(NamedTuple):
+@dataclass
+class PublishConfirmRecords:
     """Data class to track RabbitMQ activity metadata
 
     Args:
@@ -38,10 +40,10 @@ class PublishedMessages(NamedTuple):
         nacked (int): Count of unacknowledged RabbitMQ messages
         message_number (int): The ID which will be assigned to the next published message
     """
-    deliveries: Dict[int, str] = {}
-    acked = 0
-    nacked = 0
-    message_number = 0
+    deliveries: Dict[int, str] = field(default_factory=dict)
+    acked: int = 0
+    nacked: int = 0
+    message_number: int = 0
 
 
 class PublishConfirm(Thread):
@@ -64,7 +66,7 @@ class PublishConfirm(Thread):
         self._connection: Optional[SelectConnection] = None
         self._channel: Optional[Channel] = None
 
-        self._records = PublishedMessages()
+        self._records = PublishConfirmRecords()
 
         self._stopping = False
         self._url = (f'amqp://{conn.username}:{conn.password}@{conn.host}'


### PR DESCRIPTION
## Linear Issue
N/A

## Changes
- Modify publish_confirm._records object to use [Python dataclass](https://docs.python.org/3/library/dataclasses.html?highlight=dataclass#dataclasses.dataclass) instead of NamedTuple


## Reason
PublishConfirm was unusable in its current state, throwing an exception every time you called `publish_message()`:
```
AttributeError("'PublishedMessages' object attribute 'message_number' is read-only")
```

This was due to `self._records` being a NamedTuple--all attributes are immutable. NamedTuple was a poor choice on my part, since the _records object specifically exists to track (and update) message metrics like `message_number`. 


### Option B: keep using NamedTuple
There is a possible solution where you re-assign the entire NamedTuple using `NamedTuple._replace()` every time any attribute changes, for example:
```python
  self._records = self._records._replace(
    message_number=message_number + 1
  )
```
but that looks complicated enough that I thought it was a misuse of NamedTuple.

The same functionality if dataclass is used:
```python
  self._records.message_number += 1
```