### PR TITLE
bug: idsse-429: PublishConfirm wait for internal setup

### DIFF
--- a/python/idsse_common/idsse/common/publish_confirm.py
+++ b/python/idsse_common/idsse/common/publish_confirm.py
@@ -8,6 +8,7 @@
 # Contributors:
 #     Geary Layne (1)
 #     Paul Hamer (2)
+#     Mackenzie Grimes (2)
 # ----------------------------------------------------------------------------------
 # pylint: disable=C0111,C0103,R0205
 

--- a/python/idsse_common/idsse/common/publish_confirm.py
+++ b/python/idsse_common/idsse/common/publish_confirm.py
@@ -136,6 +136,11 @@ class PublishConfirm(Thread):
             logger.error('Publish message problem : %s', str(e))
             return False
 
+    def start(self):
+        """Start thread to connect RabbitMQ queue and prepare to publish messages."""
+        super().start()
+        time.sleep(.2)
+
     def run(self):
         """Run the thread, i.e. get connection etc..."""
         set_corr_id_context_var('PublishConfirm')

--- a/python/idsse_common/idsse/common/publish_confirm.py
+++ b/python/idsse_common/idsse/common/publish_confirm.py
@@ -136,11 +136,6 @@ class PublishConfirm(Thread):
             logger.error('Publish message problem : %s', str(e))
             return False
 
-    def start(self):
-        """Start thread to connect RabbitMQ queue and prepare to publish messages."""
-        super().start()
-        time.sleep(.2)
-
     def run(self):
         """Run the thread, i.e. get connection etc..."""
         set_corr_id_context_var('PublishConfirm')
@@ -154,6 +149,11 @@ class PublishConfirm(Thread):
         if self._connection is not None and not self._connection.is_closed:
             # Finish closing
             self._connection.ioloop.start()
+
+    def start(self):
+        """Start thread to connect RabbitMQ queue and prepare to publish messages."""
+        super().start()
+        time.sleep(.2)
 
     def stop(self):
         """Stop the example by closing the channel and connection. We

--- a/python/idsse_common/idsse/common/publish_confirm.py
+++ b/python/idsse_common/idsse/common/publish_confirm.py
@@ -185,7 +185,7 @@ class PublishConfirm(Thread):
 
             logger.debug('Connection and channel setup complete, ready to publish message')
 
-    def _start_with_callback(self, callback: Optional[Callable[[], None]]):
+    def _start_with_callback(self, callback: Callable[[], None]):
         """Start thread to connect to RabbitMQ queue and prepare to publish messages, invoking
         callback when setup complete.
 

--- a/python/idsse_common/idsse/common/publish_confirm.py
+++ b/python/idsse_common/idsse/common/publish_confirm.py
@@ -106,7 +106,7 @@ class PublishConfirm(Thread):
 
         Args:
             message (Dict): message to publish (should be valid json)
-            key (str): routing_key to route the message to correct consumer. Default is empty str
+            routing_key (str): routing_key to route the message to correct consumer. Default is empty str
             corr_id (Optional[str]): optional correlation_id to include in message
 
         Returns:

--- a/python/idsse_common/idsse/common/publish_confirm.py
+++ b/python/idsse_common/idsse/common/publish_confirm.py
@@ -155,8 +155,8 @@ class PublishConfirm():
         self._stopping = False  # done stopping
 
     def _run(self):
-        """Run the thread, i.e. get connection etc..."""
-        self._connection = self._connect()
+        """Run a new thread: get a new RMQ connection, and start looping until stop() is called"""
+        self._connection = self._create_connection()
         self._connection.ioloop.start()
         time.sleep(0.2)
 
@@ -167,7 +167,7 @@ class PublishConfirm():
             # Finish closing
             self._connection.ioloop.start()
 
-    def _connect(self):
+    def _create_connection(self):
         """This method connects to RabbitMQ, returning the connection handle.
         When the connection is established, the on_connection_open method
         will be invoked by pika.

--- a/python/idsse_common/idsse/common/rabbitmq_utils.py
+++ b/python/idsse_common/idsse/common/rabbitmq_utils.py
@@ -34,3 +34,9 @@ class Queue(NamedTuple):
     durable: bool
     exclusive: bool
     auto_delete: bool
+
+
+class RabbitMqParams(NamedTuple):
+    """Data class to hold configurations for RabbitMQ exchange/queue pair"""
+    exchange: Exch
+    queue: Queue

--- a/python/idsse_common/test/test_publish_confirm.py
+++ b/python/idsse_common/test/test_publish_confirm.py
@@ -218,7 +218,7 @@ def test_start_with_callback(publish_confirm: PublishConfirm):
         assert success
 
     assert publish_confirm._channel is None
-    publish_confirm.start(test_callback)
+    publish_confirm._start(test_callback)
 
     sleep(.1)  # ensure that our test's callback has time to run and send its message
     assert publish_confirm._records.message_number == 1

--- a/python/idsse_common/test/test_publish_confirm.py
+++ b/python/idsse_common/test/test_publish_confirm.py
@@ -145,7 +145,6 @@ def publish_confirm(monkeypatch: MonkeyPatch, context: MockPika) -> PublishConfi
 # tests
 def test_publish_confirm_start_and_stop(publish_confirm: PublishConfirm):
     publish_confirm.start()
-    sleep(0.1)  # allow thread to start
 
     assert publish_confirm._connection and publish_confirm._connection.is_open
     assert publish_confirm._channel and publish_confirm._channel.is_open
@@ -167,7 +166,6 @@ def test_delivery_confirmation_handles_nack(publish_confirm: PublishConfirm, con
     context.Channel.confirm_delivery = mock_confirm_delivery
 
     publish_confirm.start()
-    sleep(0.1)
     assert publish_confirm._records.nacked == 1
     assert publish_confirm._records.acked == 0
 
@@ -222,9 +220,28 @@ def test_start_with_callback(publish_confirm: PublishConfirm):
     assert publish_confirm._channel is None
     publish_confirm._start_with_callback(test_callback)
 
-    sleep(.1)  # ensure that callback has time to run and send its message
+    sleep(.1)  # ensure that our test's callback has time to run and send its message
     assert publish_confirm._records.message_number == 1
     assert publish_confirm._records.deliveries[1] == example_message
+
+
+def test_start_without_callback_sleeps(publish_confirm: PublishConfirm, monkeypatch: MonkeyPatch):
+    def mock_sleep_function(secs: float):
+        # If this is not the call originating from PublishConfirm.start(), let it really sleep.
+        # Mocking all sleep() calls seemed to break Thread operations (unit test ran forever)
+        if secs != 0.2:
+            sleep(secs)
+
+    mock_sleep = Mock(wraps=mock_sleep_function)
+    monkeypatch.setattr('idsse.common.publish_confirm.time.sleep', mock_sleep)
+
+    # if no callback passed, start() should sleep internally to ensure RabbitMQ callbacks complete
+    publish_confirm.start()
+
+    # mock sleep someimtes captures a call from PublishConfirm.run(), due to a race condition
+    # between this test's thread and the PublishConfirm thread. Both results are acceptable
+    sleep_call_args = [call.args for call in mock_sleep.call_args_list]
+    assert set(sleep_call_args) in [set([(0.2,)]), set([(0.2,), (5,)])]
 
 
 def test_wait_for_channel_returns_when_ready(monkeypatch: MonkeyPatch, context: MockPika):

--- a/python/idsse_common/test/test_publish_confirm.py
+++ b/python/idsse_common/test/test_publish_confirm.py
@@ -16,7 +16,7 @@ from time import sleep
 from typing import Callable, Union, Any, NamedTuple
 from unittest.mock import Mock
 
-from pytest import fixture, raises, MonkeyPatch
+from pytest import fixture, MonkeyPatch
 
 from pika.spec import Basic
 from idsse.common.publish_confirm import PublishConfirm
@@ -145,6 +145,7 @@ def publish_confirm(monkeypatch: MonkeyPatch, context: MockPika) -> PublishConfi
 # tests
 def test_publish_confirm_start_and_stop(publish_confirm: PublishConfirm):
     publish_confirm.start()
+    sleep(0.1)  # allow thread to start
 
     assert publish_confirm._connection and publish_confirm._connection.is_open
     assert publish_confirm._channel and publish_confirm._channel.is_open
@@ -166,38 +167,31 @@ def test_delivery_confirmation_handles_nack(publish_confirm: PublishConfirm, con
     context.Channel.confirm_delivery = mock_confirm_delivery
 
     publish_confirm.start()
+    sleep(0.1)
     assert publish_confirm._records.nacked == 1
     assert publish_confirm._records.acked == 0
 
 
-def test_publish_message_success(publish_confirm: PublishConfirm):
+def test_publish_message_success_without_calling_start(monkeypatch: MonkeyPatch, context: MockPika):
+    monkeypatch.setattr('idsse.common.publish_confirm.SelectConnection', context.SelectConnection)
+    pub_conf = PublishConfirm(conn=EXAMPLE_CONN, exchange=EXAMPLE_EXCH, queue=EXAMPLE_QUEUE)
+    example_message = {'data': [123]}
+
+    assert pub_conf._connection is None and pub_conf._channel is None
+    success = pub_conf.publish_message(example_message)
+
+    # connection & channel should have been initialized internally, so publish should have worked
+    assert success
+    assert pub_conf._channel is not None and pub_conf._channel.is_open
+    assert pub_conf._records.message_number == 1
+    assert pub_conf._records.deliveries[1] == example_message
+
+
+def test_publish_message_failure_rmq_error(publish_confirm: PublishConfirm, context: MockPika):
     message_data = {'data': 123}
 
-    publish_confirm.start()
-    result = publish_confirm.publish_message(message_data)
-
-    assert result
-    assert publish_confirm._records.message_number == 1
-    assert publish_confirm._records.deliveries[1] == message_data
-
-
-def test_publish_message_exception_when_channel_not_open(publish_confirm: PublishConfirm):
-    message_data = {'data': 123}
-
-    # missing a publish_confirm.start(), should fail
-    with raises(RuntimeError) as pytest_error:
-        publish_confirm.publish_message(message_data)
-
-    assert pytest_error is not None
-    assert 'RabbitMQ channel is None' in str(pytest_error.value)
-    assert publish_confirm._records.message_number == 0  # should not have logged message sent
-    assert len(publish_confirm._records.deliveries) == 0
-
-
-def test_publish_message_failure_rmq_error(publish_confirm: PublishConfirm):
-    message_data = {'data': 123}
-
-    publish_confirm.start()
+    publish_confirm._connection = context.SelectConnection(None, Mock(), Mock(), Mock())
+    publish_confirm._channel = context.Channel()
     publish_confirm._channel.basic_publish = Mock(side_effect=RuntimeError('ACCESS_REFUSED'))
     success = publish_confirm.publish_message(message_data)
 
@@ -208,7 +202,10 @@ def test_publish_message_failure_rmq_error(publish_confirm: PublishConfirm):
 
 
 def test_on_channel_closed(publish_confirm: PublishConfirm, context: MockPika):
-    publish_confirm.start()
+    publish_confirm._connection = context.SelectConnection(None, Mock(), Mock(), Mock())
+    publish_confirm._channel = context.Channel()
+    publish_confirm._channel.close()
+
     publish_confirm._on_channel_closed(context.Channel(), 'ChannelClosedByClient')
     assert publish_confirm._channel is None
     assert publish_confirm._connection.is_closed
@@ -223,27 +220,17 @@ def test_start_with_callback(publish_confirm: PublishConfirm):
         assert success
 
     assert publish_confirm._channel is None
-    publish_confirm.start(callback=test_callback)
+    publish_confirm._start_with_callback(test_callback)
 
     sleep(.1)  # ensure that callback has time to run and send its message
     assert publish_confirm._records.message_number == 1
     assert publish_confirm._records.deliveries[1] == example_message
 
 
-def test_start_without_callback_sleeps(publish_confirm: PublishConfirm, monkeypatch: MonkeyPatch):
-    def mock_sleep_function(secs: float):
-        # If this is not the call originating from PublishConfirm.start(), let it really sleep.
-        # Mocking all sleep() calls seemed to break Thread operations (unit test ran forever)
-        if secs != 0.2:
-            sleep(secs)
+def test_wait_for_channel_returns_when_ready(monkeypatch: MonkeyPatch, context: MockPika):
+    monkeypatch.setattr('idsse.common.publish_confirm.SelectConnection', context.SelectConnection)
+    pub_conf = PublishConfirm(conn=EXAMPLE_CONN, exchange=EXAMPLE_EXCH, queue=EXAMPLE_QUEUE)
 
-    mock_sleep = Mock(wraps=mock_sleep_function)
-    monkeypatch.setattr('idsse.common.publish_confirm.time.sleep', mock_sleep)
-
-    # if no callback passed, start() should sleep internally to ensure RabbitMQ callbacks complete
-    publish_confirm.start()
-
-    # mock sleep someimtes captures a call from PublishConfirm.run(), due to a race condition
-    # between this test's thread and the PublishConfirm thread. Both results are acceptable
-    sleep_call_args = [call.args for call in mock_sleep.call_args_list]
-    assert set(sleep_call_args) in [set([(0.2,)]), set([(0.2,), (5,)])]
+    assert pub_conf._channel is None
+    pub_conf._wait_for_channel_to_be_ready()
+    assert pub_conf._channel is not None and pub_conf._channel.is_open

--- a/python/idsse_common/test/test_publish_confirm.py
+++ b/python/idsse_common/test/test_publish_confirm.py
@@ -218,7 +218,7 @@ def test_start_with_callback(publish_confirm: PublishConfirm):
         assert success
 
     assert publish_confirm._channel is None
-    publish_confirm._start(test_callback)
+    publish_confirm.start(test_callback)
 
     sleep(.1)  # ensure that our test's callback has time to run and send its message
     assert publish_confirm._records.message_number == 1

--- a/python/idsse_common/test/test_publish_confirm.py
+++ b/python/idsse_common/test/test_publish_confirm.py
@@ -218,7 +218,7 @@ def test_start_with_callback(publish_confirm: PublishConfirm):
         assert success
 
     assert publish_confirm._channel is None
-    publish_confirm._start_with_callback(test_callback)
+    publish_confirm._start(test_callback)
 
     sleep(.1)  # ensure that our test's callback has time to run and send its message
     assert publish_confirm._records.message_number == 1


### PR DESCRIPTION
## Linear Issue
[IDSSE-429](https://linear.app/idss/issue/idsse-429)

## Changes
- On `publish_message()`, if RabbitMQ connection or channel are not ready, PublishConfirm will call setup methods internally, wait until they complete, then publish message.

Previously we required users of PublishConfirm class to call `start()` before publishing any messages, and raised an exception if they skipped that step. Now a PublishConfirm can effectively be used right after it is instantiated, without any external callbacks provided.

```python
pub_conf = PublishConfirm(params) # assume some valid RabbitMQ params
pub_conf.publish_message({'data': [123]})  # should succeed
```

_Note: callers can still invoke `start()` if they want. This will complete the exact same setup that publish_message() calls automatically when they attempt to publish their first message._

### Other publish_message changes
- Renamed arg `key` to more precise `routing_key`
  - I had previously tried to use this arg as correlation ID, didn't understand its purpose
- Added optional arg `corr_id` which will be added to message `properties.correlation_id`