### PR TITLE
Support bounding box "bbox" as list of list

### DIFF
--- a/python/idsse_common/idsse/common/schema/das_web_request.json
+++ b/python/idsse_common/idsse/common/schema/das_web_request.json
@@ -17,8 +17,12 @@
             "type": "array",
             "items": {
                 "type": "integer"
-            }
-        }
+            },
+            "minItems": 2,
+            "maxItems": 2
+        },
+        "minItems": 2,
+        "maxItems": 2
     },
 
     "DasWebRequest": {

--- a/python/idsse_common/idsse/common/schema/das_web_request.json
+++ b/python/idsse_common/idsse/common/schema/das_web_request.json
@@ -1,4 +1,26 @@
 {
+    "BBoxObj": {
+        "type": "object",
+        "properties": {
+            "botLeft": {"type": "array", "items": {"type": "integer"}, "minItems": 2, "maxItems": 2},
+            "topRight": {"type": "array", "items": {"type": "integer"}, "minItems": 2, "maxItems": 2}
+        },
+        "required": [
+            "botLeft",
+            "topRight"
+        ]
+    },
+
+    "BBoxList": {
+        "type": "array",
+        "items": {
+            "type": "array",
+            "items": {
+                "type": "integer"
+            }
+        }
+    },
+
     "DasWebRequest": {
         "description": "Mechanism for defining DAS data request via the web api",
         "type": "object",
@@ -14,14 +36,9 @@
                 "minItems": 1
             },
             "bbox": {
-                "type": "object",
-                "properties": {
-                    "botLeft": {"type": "array", "items": {"type": "integer"}, "minItems": 2, "maxItems": 2},
-                    "topRight": {"type": "array", "items": {"type": "integer"}, "minItems": 2, "maxItems": 2}
-                },
-                "required": [
-                    "botLeft",
-                    "topRight"
+                "oneOf": [
+                    {"$ref": "#/BBoxObj"},
+                    {"$ref": "#/BBoxList"}
                 ]
             }
         },

--- a/python/idsse_common/test/test_validate_das_web_schema.py
+++ b/python/idsse_common/test/test_validate_das_web_schema.py
@@ -147,8 +147,8 @@ def test_validate_das_web_request_message(das_web_request_validator: Validator,
         assert False, f'Validate message raised an exception {exc}'
 
 
-def test_validate_das_web_request_message_with_bbox_as_list(das_web_request_validator: Validator,
-                                                            das_web_request_message: dict):
+def test_validate_das_web_request_message_with_bbox_list(das_web_request_validator: Validator,
+                                                         das_web_request_message: dict):
     bbox = das_web_request_message.pop('bbox')
     das_web_request_message['bbox'] = [bbox['botLeft'], bbox['topRight']]
     try:
@@ -157,8 +157,20 @@ def test_validate_das_web_request_message_with_bbox_as_list(das_web_request_vali
         assert False, f'Validate message raised an exception {exc}'
 
 
-def test_validate_das_web_request_message_bad_bbox(das_web_request_validator: Validator,
-                                                   das_web_request_message: dict):
+def test_validate_das_web_request_message_bad_bbox_list(das_web_request_validator: Validator,
+                                                        das_web_request_message: dict):
+    bbox = das_web_request_message.pop('bbox')
+    bot_left = bbox['botLeft']
+    top_right = bbox['topRight']
+    # move one value from bottom  and adding to top, making neither represent a coordinate
+    top_right.append(bot_left.pop(1))
+    das_web_request_message['bbox'] = [bot_left, top_right]
+    with raises(ValidationError):
+        das_web_request_validator.validate(das_web_request_message)
+
+
+def test_validate_das_web_request_message_bad_bbox_obj(das_web_request_validator: Validator,
+                                                       das_web_request_message: dict):
     # replace the bottom left int coordinate with a float
     das_web_request_message['bbox']['botLeft'][0] = 1.2
     with raises(ValidationError):

--- a/python/idsse_common/test/test_validate_das_web_schema.py
+++ b/python/idsse_common/test/test_validate_das_web_schema.py
@@ -147,6 +147,16 @@ def test_validate_das_web_request_message(das_web_request_validator: Validator,
         assert False, f'Validate message raised an exception {exc}'
 
 
+def test_validate_das_web_request_message_with_bbox_as_list(das_web_request_validator: Validator,
+                                                            das_web_request_message: dict):
+    bbox = das_web_request_message.pop('bbox')
+    das_web_request_message['bbox'] = [bbox['botLeft'], bbox['topRight']]
+    try:
+        das_web_request_validator.validate(das_web_request_message)
+    except ValidationError as exc:
+        assert False, f'Validate message raised an exception {exc}'
+
+
 def test_validate_das_web_request_message_bad_bbox(das_web_request_validator: Validator,
                                                    das_web_request_message: dict):
     # replace the bottom left int coordinate with a float


### PR DESCRIPTION
Linear 473

This is a subtask of Linear 442 (PR in DAS), which now assumes coordinates are now always (x,y) and support two different structures for the bounding box in the json request. This PR is the corresponding update to the schema for the additional valid structure. 

Previously support struct:
`"bbox": {
            "botLeft": [100, 102],
            "topRight": [200, 202]
        }`

New (additional) struct:
`"bbox": [[100, 102],  [200, 202]]`
