### PR TITLE
Added dataDescript to EventPort

### DIFF
--- a/python/idsse_common/idsse/common/schema/risk_results.json
+++ b/python/idsse_common/idsse/common/schema/risk_results.json
@@ -1,4 +1,26 @@
 {
+    "DataDescription": {
+        "description": "Identification of the data used for evaluation",
+        "properties": {
+            "partName": {
+                "type": "string"
+            },
+            "dataName": {
+                "type": "string"
+            },
+            "dataLocation": {
+                "type": "string"
+            },
+            "issueDt": {"$ref": "timing.json#/TimeString"}
+        },
+        "required": [
+            "partName",
+            "dataName",
+            "dataLocation",
+            "issueDt"
+        ]
+    }, 
+
     "SingleValue": {
         "description": "Mechanism for storing the 'Single Value' result for a specific Condition/Location/Product(s)",
         "type": "object",
@@ -107,6 +129,7 @@
             "locationKey": {"type": "string"},
             "productKey": {"type": "string"},
             "validDt": {"type": "array", "items": {"$ref": "timing.json#/TimeString"}, "minItems": 1},
+            "dataDescript": {"type": "array", "items": {"$ref": "#/DataDescription"}, "minItems": 1},
             "data": {"type": "array", "items": {"$ref": "#/Data"}, "minItems": 2},
             "metaData": {"type": "array", "items": {"$ref": "#/MetaData"}, "minItems": 1}
         },
@@ -116,6 +139,7 @@
             "locationKey",
             "productKey",                    
             "validDt",
+            "dataDescript",
             "data",
             "metaData"
         ]

--- a/python/idsse_common/test/test_validate_event_port_schema.py
+++ b/python/idsse_common/test/test_validate_event_port_schema.py
@@ -100,6 +100,14 @@ def simple_event_port_message() -> dict:
                 "validDt": [
                     "2022-11-12T00:00:00.000Z"
                 ],
+                "dataDescript": [
+                    {
+                        "partName": "B",
+                        "dataName": "Temperature: 2m",
+                        "dataLocation": "arn:aws:s3:::noaa-nbm-grib2-pds:",
+                        "issueDt": "2022-11-11T14:00:00.000Z"
+                    }
+                ],
                 "data": [
                     {
                         "name": "Abq TEMP",


### PR DESCRIPTION
Linear 502

This is the first part in getting our sample eventPorts up to date. This is the update to the eventPort schema to require the dataDescript, which hold the info about what/where the raw data was accessed.