### PR TITLE
Updated regex to match scientific notation

### DIFF
--- a/python/idsse_common/idsse/common/schema/risk_results.json
+++ b/python/idsse_common/idsse/common/schema/risk_results.json
@@ -38,8 +38,8 @@
         "description": "Value found in data and the number of time found",
         "type": "object",
         "patternProperties": {
-            "^[-+]?[0-9]*[.]?[0-9]+$": {"type": "integer"},
-            "[^0-9.+-]": {"not": {}}
+            "[+-]?(?:0|[1-9]d*)(?:.d+)?(?:[eE][+-]?d+)?": {"type": "integer"},
+            "[^0-9.+-E]": {"not": {}}
         },
         "minProperties": 1
     },

--- a/python/idsse_common/test/test_validate_event_port_schema.py
+++ b/python/idsse_common/test/test_validate_event_port_schema.py
@@ -141,7 +141,7 @@ def simple_event_port_message() -> dict:
                         ],
                         "geoDist": [
                             {
-                                "38.53400802612305": 1
+                                "1.7941197416604382E-9": 1
                             }
                         ]
                     }


### PR DESCRIPTION
Linear 502

Last part of updating eventPort, corrected regex to include support for scientific notation.