### PR TITLE
bug: set pytest to exit on failure

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pylint==2.17.5 python-dateutil==2.8.2 pint==0.21 importlib-metadata==6.7.0 jsonschema==4.19.0 pika==1.3.1 pyproj numpy==1.26.2 shapely==2.0.2 netcdf4==1.6.3 h5netcdf==1.1.0 pillow==10.2.0
+          pip install pytest pylint==2.17.5 python-dateutil==2.8.2 pint==0.21 importlib-metadata==6.7.0 jsonschema==4.19.0 pika==1.3.1 pyproj numpy==1.26.2 shapely==2.0.2 netcdf4==1.6.3 h5netcdf==1.1.0 pillow==10.2.0 python-logging-rabbitmq==2.3.0
 
       - name: Set PYTHONPATH for pylint
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pylint==2.17.5 python-dateutil==2.8.2 pint==0.21 importlib-metadata==6.7.0 jsonschema==4.19.0 pika==1.3.1 pyproj==3.6.1 numpy==1.26.2 shapely==2.0.2 netcdf4==1.6.3 h5netcdf==1.1.0 pytest-cov==4.1.0  pillow==10.2.0
+          pip install pytest pylint==2.17.5 python-dateutil==2.8.2 pint==0.21 importlib-metadata==6.7.0 jsonschema==4.19.0 pika==1.3.1 pyproj==3.6.1 numpy==1.26.2 shapely==2.0.2 netcdf4==1.6.3 h5netcdf==1.1.0 pytest-cov==4.1.0  pillow==10.2.0 python-logging-rabbitmq==2.3.0
 
       - name: Set PYTHONPATH for pytest
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,8 +31,10 @@ jobs:
 
       - name: Test with pytest
         working-directory: python/idsse_common
+        # run Pytest, exiting nonzero if pytest throws errors (otherwise "| tee" obfuscates)
         run: |
-          pytest ./test --cov=./idsse/common --cov-report=term --junitxml=./test/pytest.xml | tee ./test/coverage.txt
+          set -o pipefail;
+          pytest ./test --cov=./idsse/common --cov-report=term --junitxml=./test/pytest.xml | tee ./test/coverage.txt;
 
       - name: Pytest coverage comment
         if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-558](https://linear.app/idss/issue/IDSSE-558)

### Changes
<!-- Brief description of changes -->
- In GitHub Action, set pytest to exit immediately on failure.

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
We pipe the output of `pytest` to `tee`, which dumps output to a txt file for test coverage reports later. However, this was eating the exit code of pytest, so `tee` would exit 0 and GitHub called the tests "passing", even when pytest exited nonzero due to failing tests