### PR TITLE
feat: idsse-763: simple pika RMQ publisher

### DIFF
--- a/python/idsse_common/idsse/common/rabbitmq_utils.py
+++ b/python/idsse_common/idsse/common/rabbitmq_utils.py
@@ -38,7 +38,7 @@ class Conn(NamedTuple):
     username: str
     password: str
 
-    def to_connection(self,) -> BlockingConnection:
+    def to_connection(self) -> BlockingConnection:
         """Establish a new RabbitMQ connection using attributes in Conn data class
 
         Returns:

--- a/python/idsse_common/idsse/common/rabbitmq_utils.py
+++ b/python/idsse_common/idsse/common/rabbitmq_utils.py
@@ -248,6 +248,6 @@ class SimplePublisher:
             logger.debug('Published message to exchange %s, queue %s, routing_key %s',
                          self._exchange_name, self._queue_name, routing_key)
             return True  # seems like it worked
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            logger.error('Publish message problem: [%s] %s', type(e), str(e))
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.error('Publish message problem: [%s] %s', type(exc), str(exc))
             return False

--- a/python/idsse_common/test/test_rabbitmq_utils.py
+++ b/python/idsse_common/test/test_rabbitmq_utils.py
@@ -20,7 +20,7 @@ from pika import BlockingConnection
 from pika.adapters import blocking_connection
 
 from idsse.common.rabbitmq_utils import (
-    Conn, Exch, Queue, RabbitMqParams, SimplePublisher, subscribe_to_queue
+    Conn, Exch, Queue, RabbitMqParams, PublisherSync, subscribe_to_queue
 )
 
 # Example data objects
@@ -202,7 +202,7 @@ def test_simple_publisher(monkeypatch: MonkeyPatch, mock_connection: Mock):
         'idsse.common.rabbitmq_utils.BlockingConnection', mock_blocking_connection
     )
 
-    publisher = SimplePublisher(CONN, RMQ_PARAMS)
+    publisher = PublisherSync(CONN, RMQ_PARAMS)
     mock_blocking_connection.assert_called_once()
     _channel = mock_blocking_connection.return_value.channel
     _channel.assert_called_once()

--- a/python/idsse_common/test/test_rabbitmq_utils.py
+++ b/python/idsse_common/test/test_rabbitmq_utils.py
@@ -19,7 +19,9 @@ from pytest import fixture, raises, MonkeyPatch
 from pika import BlockingConnection
 from pika.adapters import blocking_connection
 
-from idsse.common.rabbitmq_utils import Conn, Exch, Queue, RabbitMqParams, subscribe_to_queue
+from idsse.common.rabbitmq_utils import (
+    Conn, Exch, Queue, RabbitMqParams, SimplePublisher, subscribe_to_queue
+)
 
 # Example data objects
 CONN = Conn('localhost', '/', port=5672, username='user', password='password')
@@ -190,3 +192,26 @@ def test_default_exchange_does_not_try_to_declare_exchange(
     new_channel.exchange_declare.assert_not_called()
     new_channel.queue_declare.assert_called_once()
     new_channel.basic_consume.assert_called_once()
+
+
+def test_simple_publisher(monkeypatch: MonkeyPatch, mock_connection: Mock):
+    # add mock to get Connnection callback to invoke immediately
+    mock_connection.add_callback_threadsafe = Mock(side_effect=lambda callback: callback())
+    mock_blocking_connection = Mock(return_value=mock_connection)
+    monkeypatch.setattr(
+        'idsse.common.rabbitmq_utils.BlockingConnection', mock_blocking_connection
+    )
+
+    publisher = SimplePublisher(CONN, RMQ_PARAMS)
+    mock_blocking_connection.assert_called_once()
+    _channel = mock_blocking_connection.return_value.channel
+    _channel.assert_called_once()
+    assert publisher._connection == mock_connection
+
+    result = publisher.publish_message({'data': 123})
+    assert result
+    _channel.return_value.basic_publish.assert_called_once()
+
+    publisher.close()
+    _channel.return_value.close.assert_called_once()
+    mock_blocking_connection.return_value.close.assert_called_once()


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-763](https://linear.app/idss/issue/IDSSE-763)

### Changes
<!-- Brief description of changes -->
- Create `PublisherSync` class, which connects to RabbitMQ on init, has a `publish_message()` method like PublishConfirm, and a `close()` method to cleanup connection

Unlike PublishConfirm, this class does not manually track or guarantee message delivery, and does not create a separate thread to ensure thread safety. Just a simple wrapper of pika's `basic_publish()` to send messages (_probably_) to a given exchange & queue.
 
### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
PublishConfirm has been experiencing some strange thread lock issues which prevent it from starting up and connecting to RabbitMQ. They've only occurred in the dev environment so far (haven't been replicated locally).

This utility class will at least simplify troubleshooting for services like RiskProcessor while we hone in on the source of the bug. I would like to switch back to using PublishConfirm after we've solved the bug and can be sure multi-threading is working correctly.