### PR TITLE
Chore/idsse 788/add reconnect

### DIFF
--- a/python/idsse_common/idsse/common/rabbitmq_utils.py
+++ b/python/idsse_common/idsse/common/rabbitmq_utils.py
@@ -166,7 +166,7 @@ def subscribe_to_queue(
     close gracefully with connection.close()
 
     Args:
-        conn (Conn | BlockingConnection): connection parameters to establish new
+        connection (Conn | BlockingConnection): connection parameters to establish new
             RabbitMQ connection, or existing RabbitMQ connection to reuse for this consumer.
         rmq_params (RabbitMqParams): parameters for the RabbitMQ exchange and queue from which to
             consume messages.

--- a/python/idsse_common/idsse/common/rabbitmq_utils.py
+++ b/python/idsse_common/idsse/common/rabbitmq_utils.py
@@ -220,7 +220,7 @@ class PublisherSync:
         self._connection, self._channel, self._queue_name = _initialize_connection_and_channel(
             conn_params, rmq_params, channel,
         )
-        self._exchange_name = rmq_params.exchange.name
+
         self._channel.confirm_delivery()  # enable delivery confirmations from RabbitMQ broker
 
     def close(self):
@@ -250,7 +250,7 @@ class PublisherSync:
                                      content_encoding='utf-8',
                                      correlation_id=corr_id)
         try:
-            self._channel.basic_publish(self._exchange_name, routing_key,
+            self._channel.basic_publish(self._rmq_params.exchange.name, routing_key,
                                         json.dumps(message, ensure_ascii=True), properties)
 
             return True
@@ -258,7 +258,7 @@ class PublisherSync:
             try:
                 self._connection, self._channel, self._queue_name = \
                     _initialize_connection_and_channel(self._conn_params, self._rmq_params)
-                self._channel.basic_publish(self._exchange_name, routing_key,
+                self._channel.basic_publish(self._rmq_params.exchange.name, routing_key,
                                             json.dumps(message, ensure_ascii=True), properties)
 
                 return True

--- a/python/idsse_common/idsse/common/rabbitmq_utils.py
+++ b/python/idsse_common/idsse/common/rabbitmq_utils.py
@@ -148,7 +148,7 @@ def _initialize_connection_and_channel(
 
 
 def subscribe_to_queue(
-    conn: Conn | BlockingConnection,
+    connection: Conn | BlockingConnection,
     rmq_params: RabbitMqParams,
     on_message_callback: Callable[
         [BlockingChannel, Basic.Deliver, BasicProperties, bytes], None],
@@ -181,7 +181,7 @@ def subscribe_to_queue(
             and subscribed to the provided queue.
     """
     _connection, _channel, queue_name = _initialize_connection_and_channel(
-        conn, rmq_params, channel
+        connection, rmq_params, channel
     )
 
     # begin consuming messages

--- a/python/idsse_common/idsse/common/rabbitmq_utils.py
+++ b/python/idsse_common/idsse/common/rabbitmq_utils.py
@@ -17,7 +17,7 @@ import logging.config
 from collections.abc import Callable
 from typing import NamedTuple
 
-from pika import BasicProperties, ConnectionParameters, PlainCredentials
+from pika import AMQPConnectionError, BasicProperties, ConnectionParameters, PlainCredentials
 from pika.adapters import BlockingConnection
 from pika.channel import Channel
 from pika.adapters.blocking_connection import BlockingChannel
@@ -147,8 +147,8 @@ def _initialize_connection_and_channel(
 
 
 def subscribe_to_queue(
-    connection: Conn | BlockingConnection,
-    params: RabbitMqParams,
+    conn_params: Conn | BlockingConnection,
+    rmq_params: RabbitMqParams,
     on_message_callback: Callable[
         [BlockingChannel, Basic.Deliver, BasicProperties, bytes], None],
     channel: BlockingChannel | None = None
@@ -165,9 +165,9 @@ def subscribe_to_queue(
     close gracefully with connection.close()
 
     Args:
-        connection (Conn | BlockingConnection): connection parameters to establish new
+        conn_params (Conn | BlockingConnection): connection parameters to establish new
             RabbitMQ connection, or existing RabbitMQ connection to reuse for this consumer.
-        params (RabbitMqParams): parameters for the RabbitMQ exchange and queue from which to
+        rmq_params (RabbitMqParams): parameters for the RabbitMQ exchange and queue from which to
             consume messages.
         on_message_callback (Callable[
             [BlockingChannel, Basic.Deliver, BasicProperties, bytes], None]):
@@ -180,7 +180,7 @@ def subscribe_to_queue(
             and subscribed to the provided queue.
     """
     _connection, _channel, queue_name = _initialize_connection_and_channel(
-        connection, params, channel
+        conn_params, rmq_params, channel
     )
 
     # begin consuming messages
@@ -200,24 +200,27 @@ class PublisherSync:
     you're done with it using close().
 
     Args:
-        connection (Conn | BlockingConnection): connection parameters to establish a new
+        conn_params (Conn | BlockingConnection): connection parameters to establish a new
             RabbitMQ connection, or existing RabbitMQ to reuse
-        params (RabbitMqParams): parameters for RabbitMQ exchange and queue on which to publish
+        rmq_params (RabbitMqParams): parameters for RabbitMQ exchange and queue on which to publish
             messages
     """
     def __init__(
         self,
-        connection: Conn | BlockingConnection,
-        params: RabbitMqParams,
+        conn_params: Conn | BlockingConnection,
+        rmq_params: RabbitMqParams,
         channel: Channel | None = None,
     ) -> tuple[BlockingConnection, Channel]:
+        # save params
+        self._conn_params = conn_params
+        self._rmq_params = rmq_params
 
         # establish BlockingConnection and declare exchange and queue on Channel
         self._connection, self._channel, self._queue_name = _initialize_connection_and_channel(
-            connection, params, channel,
+            conn_params, rmq_params, channel,
         )
-        self._exchange_name = params.exchange.name
-        self._channel.confirm_delivery() # enable delivery confirmations from RabbitMQ broker
+        self._exchange_name = rmq_params.exchange.name
+        self._channel.confirm_delivery()  # enable delivery confirmations from RabbitMQ broker
 
     def close(self):
         """Cleanly close any open RabbitMQ connection and channel"""
@@ -241,14 +244,23 @@ class PublisherSync:
         Returns:
             bool: True if message was published to the queue
         """
+
+        properties = BasicProperties(content_type='application/json',
+                                     content_encoding='utf-8',
+                                     correlation_id=corr_id)
         try:
-            properties = BasicProperties(content_type='application/json',
-                                         content_encoding='utf-8',
-                                         correlation_id=corr_id)
             self._channel.basic_publish(self._exchange_name, routing_key,
                                         json.dumps(message, ensure_ascii=True), properties)
 
             return True
-        except Exception as exc:  # pylint: disable=broad-exception-caught
-            logger.error('Publish message problem: [%s] %s', type(exc), str(exc))
-            return False
+        except AMQPConnectionError:  # pylint: disable=broad-exception-caught
+            try:
+                self._connection, self._channel, self._queue_name = \
+                    _initialize_connection_and_channel(self._conn_params, self._rmq_params)
+                self._channel.basic_publish(self._exchange_name, routing_key,
+                                            json.dumps(message, ensure_ascii=True), properties)
+
+                return True
+            except AMQPConnectionError as exc:  # pylint: disable=broad-exception-caught
+                logger.error('Publish message problem: [%s] %s', type(exc), str(exc))
+                return False

--- a/python/idsse_common/idsse/common/rabbitmq_utils.py
+++ b/python/idsse_common/idsse/common/rabbitmq_utils.py
@@ -148,7 +148,7 @@ def _initialize_connection_and_channel(
 
 
 def subscribe_to_queue(
-    conn_params: Conn | BlockingConnection,
+    conn: Conn | BlockingConnection,
     rmq_params: RabbitMqParams,
     on_message_callback: Callable[
         [BlockingChannel, Basic.Deliver, BasicProperties, bytes], None],
@@ -166,7 +166,7 @@ def subscribe_to_queue(
     close gracefully with connection.close()
 
     Args:
-        conn_params (Conn | BlockingConnection): connection parameters to establish new
+        conn (Conn | BlockingConnection): connection parameters to establish new
             RabbitMQ connection, or existing RabbitMQ connection to reuse for this consumer.
         rmq_params (RabbitMqParams): parameters for the RabbitMQ exchange and queue from which to
             consume messages.
@@ -181,7 +181,7 @@ def subscribe_to_queue(
             and subscribed to the provided queue.
     """
     _connection, _channel, queue_name = _initialize_connection_and_channel(
-        conn_params, rmq_params, channel
+        conn, rmq_params, channel
     )
 
     # begin consuming messages

--- a/python/idsse_common/idsse/common/rabbitmq_utils.py
+++ b/python/idsse_common/idsse/common/rabbitmq_utils.py
@@ -17,10 +17,11 @@ import logging.config
 from collections.abc import Callable
 from typing import NamedTuple
 
-from pika import AMQPConnectionError, BasicProperties, ConnectionParameters, PlainCredentials
+from pika import BasicProperties, ConnectionParameters, PlainCredentials
 from pika.adapters import BlockingConnection
-from pika.channel import Channel
 from pika.adapters.blocking_connection import BlockingChannel
+from pika.channel import Channel
+from pika.exceptions import AMQPConnectionError
 from pika.frame import Method
 from pika.spec import Basic
 
@@ -200,14 +201,14 @@ class PublisherSync:
     you're done with it using close().
 
     Args:
-        conn_params (Conn | BlockingConnection): connection parameters to establish a new
-            RabbitMQ connection, or existing RabbitMQ to reuse
+        conn_params (Conn): connection parameters to establish a new
+            RabbitMQ connection
         rmq_params (RabbitMqParams): parameters for RabbitMQ exchange and queue on which to publish
             messages
     """
     def __init__(
         self,
-        conn_params: Conn | BlockingConnection,
+        conn_params: Conn,
         rmq_params: RabbitMqParams,
         channel: Channel | None = None,
     ) -> tuple[BlockingConnection, Channel]:


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-788](https://linear.app/idss/issue/IDSSE-788)

### Changes
<!-- Brief description of changes -->
- Save off connection param to use if basic publish fails
- On basic publish fail, reconnect and try again
- PublisherSync no longer can take a preexisting BlockingConnection, only params

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
I did not at testing for this since I don't know how and PublisherSync is being used temporarily