### PR TITLE
bug: idsse-795: PublishConfirm setup timeout

### DIFF
--- a/python/idsse_common/idsse/common/publish_confirm.py
+++ b/python/idsse_common/idsse/common/publish_confirm.py
@@ -178,7 +178,7 @@ class PublishConfirm:
             # Finish closing
             self._connection.ioloop.start()
 
-    def _start(self, on_ready: Future | None = None):
+    def _start(self, is_ready: Future | None = None):
         """
         Start a thread to handle PublishConfirm operations
 
@@ -189,8 +189,8 @@ class PublishConfirm:
                 if some issue is encountered in that process. Defaults to None.
         """
         logger.debug('Starting thread with callback')
-        if on_ready is not None:
-            self._is_ready_future = on_ready  # to be invoked after all pika setup is done
+        if is_ready is not None:
+            self._is_ready_future = is_ready  # to be invoked after all pika setup is done
         self._thread.start()
 
     def _create_connection(self):
@@ -236,7 +236,7 @@ class PublishConfirm:
         is_ready_future = Future()
 
         logger.info('calling _start() with callback')
-        self._start(on_ready=is_ready_future)
+        self._start(is_ready=is_ready_future)
 
         logger.info('waiting for is_ready flag to be set')
         try:
@@ -314,8 +314,8 @@ class PublishConfirm:
             self._channel.exchange_declare(exchange=exch_name,
                                        exchange_type=exch_type,
                                        callback=cb)
-        except Exception as exc:  # pylint: disable=broad-exception-caught
-            logger.warning('RabbitMQ failed to declare exchange: [%s] %s', type(exc), str(exc))
+        except ValueError as exc:
+            logger.warning('RabbitMQ failed to declare exchange: (%s) %s', type(exc), str(exc))
             if self._is_ready_future:
                 self._is_ready_future.set_exception(exc)  # notify caller that we could not connect
 


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-795](https://linear.app/idss/issue/IDSSE-795)

### Changes
<!-- Brief description of changes -->
- Add optional timeout to PublishConfirm `_wait_for_channel_to_be_ready()`. Default is 6 seconds
- If RabbitMQ setup did not work, or did not respond after 6 seconds, give up trying to publish the message, and immediately return to the caller to let them know.

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
My current theory is that PublishConfirm hanging/deadlocking bug was due to the child Thread failing for some reason to connection to RabbitMQ and declare its exchange/queue... but because it's not the main thread, no logs appear in the console/stdout to help us troubleshoot.

These changes may not resolve any issues, but it will surface them more clearly, by creating a Python `Future` which the RabbitMQ setup callbacks will either resolve to True if everything worked, or an exception if RabbitMQ throws one, or timeout after 6 seconds.