### PR TITLE
chore: add stop() method to PublisherSync

### DIFF
--- a/python/idsse_common/idsse/common/rabbitmq_utils.py
+++ b/python/idsse_common/idsse/common/rabbitmq_utils.py
@@ -223,6 +223,11 @@ class PublisherSync:
 
         self._channel.confirm_delivery()  # enable delivery confirmations from RabbitMQ broker
 
+    def stop(self):
+        """Cleanly close ("stop") any open RabbitMQ connection and channel. This has the same
+        functionality as close(), it's just to match the interface of ```PublishConfirm```"""
+        self.close()
+
     def close(self):
         """Cleanly close any open RabbitMQ connection and channel"""
         def _close_connection():

--- a/python/idsse_common/test/test_rabbitmq_utils.py
+++ b/python/idsse_common/test/test_rabbitmq_utils.py
@@ -154,7 +154,8 @@ def test_passing_channel_does_not_create_new(mock_connection: Mock, mock_channel
     new_channel.basic_consume.assert_called_once()
     assert new_channel == mock_channel
 
-def test_direct_reply_does_not_try_to_declare_queue(
+
+def test_direct_reply_does_not_declare_queue(
     monkeypatch: MonkeyPatch, mock_connection: Mock
 ):
     params = RabbitMqParams(
@@ -174,7 +175,7 @@ def test_direct_reply_does_not_try_to_declare_queue(
     new_channel.queue_bind.assert_not_called()
     new_channel.basic_consume.assert_called_once()
 
-def test_default_exchange_does_not_try_to_declare_exchange(
+def test_default_exchange_does_not_declare_exchange(
     monkeypatch: MonkeyPatch, mock_connection: Mock
 ):
     params = RabbitMqParams(
@@ -212,6 +213,6 @@ def test_simple_publisher(monkeypatch: MonkeyPatch, mock_connection: Mock):
     assert result
     _channel.return_value.basic_publish.assert_called_once()
 
-    publisher.close()
+    publisher.stop()
     _channel.return_value.close.assert_called_once()
     mock_blocking_connection.return_value.close.assert_called_once()


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-795](https://linear.app/idss/issue/IDSSE-795)

### Changes
<!-- Brief description of changes -->
- Add a `stop()` method to PublisherSync class

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
Now `PublisherSync` class will have the same public methods as `PublishConfirm`. 

This way the cutover from using PublisherSync back to using PublishConfirm should be seamless--we only need to instantiate one class or the other, and all other methods will just work.