### PR TITLE
feat: idsse-912: add optimization args to `aws_cp()`

### DIFF
--- a/python/idsse_common/idsse/common/aws_utils.py
+++ b/python/idsse_common/idsse/common/aws_utils.py
@@ -88,9 +88,9 @@ class AwsUtils():
             bool: Returns True if copy is successful
         """
         try:
-            commands = ['s5cmd', '--no-sign-request',  'cp']
             logger.debug('First attempt with s5cmd, concurrency: %d, chunk_size: %s',
                          concurrency, chunk_size)
+            commands = ['s5cmd', '--no-sign-request',  'cp']
 
             # if concurrency and/or chunk_size options were provided, append to s5cmd before paths
             if concurrency:


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-912](https://linear.app/idss/issue/IDSSE-912)

### Changes
<!-- Brief description of changes -->
- Add optional `concurrency` and `chunk_size` args to aws_cp, to change how s5cmd downloads files (hopefully improving the time to download a large file)

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
These function args let us control the number of parallel threads and size of chunks that s5cmd uses to download a single GRIB file from AWS. The defaults (what DAS was using up until now) is 5 threads, 50 MB chunks at a time, but now DAS can tweak these controls to figure out what runs the fastest in our environment.

Unfortunately s5cmd does not support downloading partial files from AWS S3 today. It's open source, so I'm hoping to contribute to the s5cmd project to get it added.