### PR TITLE
bug: aws_cp optional args should not be ints

### DIFF
--- a/python/idsse_common/idsse/common/aws_utils.py
+++ b/python/idsse_common/idsse/common/aws_utils.py
@@ -96,7 +96,7 @@ class AwsUtils():
             if concurrency:
                 commands += ['--concurrency', str(concurrency)]
             if chunk_size:
-                commands += ['--part_size', str(chunk_size)]
+                commands += ['--part-size', str(chunk_size)]
             commands += [path, dest]  # finish the command list with the src and destination
 
             exec_cmd(commands)

--- a/python/idsse_common/idsse/common/aws_utils.py
+++ b/python/idsse_common/idsse/common/aws_utils.py
@@ -94,9 +94,9 @@ class AwsUtils():
 
             # if concurrency and/or chunk_size options were provided, append to s5cmd before paths
             if concurrency:
-                commands += ['--concurrency', concurrency]
+                commands += ['--concurrency', str(concurrency)]
             if chunk_size:
-                commands += ['--part_size', chunk_size]
+                commands += ['--part_size', str(chunk_size)]
             commands += [path, dest]  # finish the command list with the src and destination
 
             exec_cmd(commands)


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
N/A

### Changes
<!-- Brief description of changes -->
- Fix bug in `aws_cp()` utility that attempted to pass non-string arguments to the exec_cmd. The underlying os command that it calls requires everything to be strings. 

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
N/A