### PR TITLE
chore: json schema: allow 'Core UI' as corrId originator

### DIFF
--- a/python/idsse_common/idsse/common/schema/corr_id.json
+++ b/python/idsse_common/idsse/common/schema/corr_id.json
@@ -5,7 +5,7 @@
         "properties": {
             "originator": {
                 "type": "string",
-                "enum": ["IDSSe", "IMS"]
+                "enum": ["IDSSe", "IMS", "Core UI"]
             },
             "uuid": {
                 "type": "string",


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
N/A

### Changes
<!-- Brief description of changes -->
- Adds "Core UI" as a valid `corrId.originator` value to JSON Schema

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
For traceability in the development environment, we would like to know which Criteria messages were system-generated by IMS-Gateway and similar long-running services, vs. ones that were created by a user through the Core UI Criteria builder page.

This new originator will let the Core UI tag each Criteria that it makes, so if/when we have an un-processable Criteria introduced into our dev environment, we at least have somewhere to start debugging if it was system created or human created.
