### PR TITLE
Removed default Queue argument dict

### DIFF
--- a/python/idsse_common/idsse/common/rabbitmq_utils.py
+++ b/python/idsse_common/idsse/common/rabbitmq_utils.py
@@ -70,7 +70,7 @@ class Queue(NamedTuple):
     durable: bool
     exclusive: bool
     auto_delete: bool
-    arguments: dict = {'x-queue-type': 'classic'}
+    arguments: dict = {}
 
 
 class RabbitMqParams(NamedTuple):

--- a/python/idsse_common/test/test_rabbitmq_utils.py
+++ b/python/idsse_common/test/test_rabbitmq_utils.py
@@ -102,7 +102,7 @@ def test_connection_params_works(monkeypatch: MonkeyPatch, mock_connection: Mock
         exclusive=RMQ_PARAMS.queue.exclusive,
         durable=RMQ_PARAMS.queue.durable,
         auto_delete=RMQ_PARAMS.queue.auto_delete,
-        arguments={'x-queue-type': 'classic'}
+        arguments={}
     )
 
     _channel.queue_bind.assert_called_once_with(
@@ -143,7 +143,7 @@ def test_private_queue_sets_ttl(monkeypatch: MonkeyPatch, mock_connection: Mock)
         exclusive=example_queue.exclusive,
         durable=example_queue.durable,
         auto_delete=example_queue.auto_delete,
-        arguments={'x-message-ttl': 10000, 'x-queue-type': 'classic'}
+        arguments={'x-message-ttl': 10000}
     )
 
 


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-860](https://linear.app/idss/issue/IDSSE-860)

### Changes
<!-- Brief description of changes -->
- While working on Linear 860 I decided it would be cleaner to not have the queue type (classic) part of the default 'arguments' dictionary (it is the default if no type is specified)

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
N/A