### PR TITLE
Lost logs from threads

### DIFF
--- a/python/idsse_common/idsse/common/log_util.py
+++ b/python/idsse_common/idsse/common/log_util.py
@@ -10,7 +10,7 @@
 #     Mackenzie Grimes (2)
 #
 # ------------------------------------------------------------------------------
-# pylint: disable=too-few-public-methods
+# pylint: disable=too-few-public-methods,missing-class-docstring
 
 import logging
 import time

--- a/python/idsse_common/idsse/common/rabbitmq_utils.py
+++ b/python/idsse_common/idsse/common/rabbitmq_utils.py
@@ -350,7 +350,7 @@ def _set_context(context):
         var.set(value)
 
 
-class Consumer(Thread):
+class Consumer(Thread):  # pylint disable=too-many-instance-attributes
     """
     RabbitMQ consumer, runs in own thread to not block heartbeat. A thread pool
     is used to not so much to parallelize the execution but rather to manage the
@@ -365,7 +365,7 @@ class Consumer(Thread):
         num_message_handlers: int,
         *args,
         **kwargs,
-    ):  # pylint disable=too-many-instance-attributes
+    ):
         super().__init__(*args, **kwargs)
         self.context = contextvars.copy_context()
         self.daemon = True

--- a/python/idsse_common/idsse/common/rabbitmq_utils.py
+++ b/python/idsse_common/idsse/common/rabbitmq_utils.py
@@ -452,7 +452,8 @@ class Publisher(Thread):
                                 durable=False,
                                 exclusive=True,
                                 auto_delete=False,
-                                arguments={'x-message-ttl': 10 * 1000})
+                                arguments={'x-queue-type': 'classic',
+                                           'x-message-ttl': 10 * 1000})
 
             _setup_exch_and_queue(self.channel, self._exch, self._queue)
         else:

--- a/python/idsse_common/idsse/common/rabbitmq_utils.py
+++ b/python/idsse_common/idsse/common/rabbitmq_utils.py
@@ -350,7 +350,7 @@ def _set_context(context):
         var.set(value)
 
 
-class Consumer(Thread):  # pylint disable=too-many-instance-attributes
+class Consumer(Thread):
     """
     RabbitMQ consumer, runs in own thread to not block heartbeat. A thread pool
     is used to not so much to parallelize the execution but rather to manage the
@@ -358,6 +358,10 @@ class Consumer(Thread):  # pylint disable=too-many-instance-attributes
     shutdown.  The start() and stop() methods should be called from the same
     thread as the one used to create the instance.
     """
+
+    # pylint: disable=too-many-instance-attributes
+    # Eight is reasonable in this case.
+
     def __init__(
         self,
         conn_params: Conn,

--- a/python/idsse_common/idsse/common/rabbitmq_utils.py
+++ b/python/idsse_common/idsse/common/rabbitmq_utils.py
@@ -365,7 +365,7 @@ class Consumer(Thread):
         num_message_handlers: int,
         *args,
         **kwargs,
-    ):
+    ):  # pylint disable=too-many-instance-attributes
         super().__init__(*args, **kwargs)
         self.context = contextvars.copy_context()
         self.daemon = True

--- a/python/idsse_common/test/test_log_util.py
+++ b/python/idsse_common/test/test_log_util.py
@@ -10,6 +10,7 @@
 #
 # ----------------------------------------------------------------------------------
 # pylint: disable=missing-function-docstring,redefined-outer-name,invalid-name,unused-argument
+# pylint: disable=missing-class-docstring
 
 import contextvars
 import logging


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-1011](https://linear.app/idss/issue/IDSSE-1011)

### Changes
<!-- Brief description of changes -->
- There wasn't so much as a bug, as missing logic
  - We use python's ContextVars to make corr_id available to logging
  - It turns out that a thread doesn't inherit ContextVars automatically
  - There are two ways to get logs from threads
    - 1) We can initialize our logger to not use corr_id `logging.config.dictConfig(get_default_log_config('INFO', with_corr_id=False))`
    - 2) Pass ContextVars to threads
  - I added tests two test_log_util.py that test getting logs from a thread running a function and from Classes that extend Threads
  - I added passing ContextVars to Consume/Publisher in rabbitmq_utils.py
- There are likely other places in our code that logs are getting lost in threads, and the test in log_util.py will serve as example code
 

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
N/A