### PR TITLE
feat: add optional channel arg to Publisher

### DIFF
--- a/python/idsse_common/idsse/common/rabbitmq_utils.py
+++ b/python/idsse_common/idsse/common/rabbitmq_utils.py
@@ -458,7 +458,8 @@ class Publisher(Thread):
             self.connection = conn_params.connection
             self.channel = conn_params
         else:
-            raise ValueError('Publisher expects RabbitMQ params (Conn) or existing Channel to run setup')
+            raise ValueError('RabbitMQ params (Conn) or existing Channel required to create' +
+                              f'Publisher thread. Unexpected type: {type(conn_params)}')
 
         # if delivery is mandatory there must be a queue attach to the exchange
         if self._exch.mandatory:

--- a/python/idsse_common/idsse/common/rabbitmq_utils.py
+++ b/python/idsse_common/idsse/common/rabbitmq_utils.py
@@ -482,7 +482,7 @@ class Publisher(Thread):
                                 exclusive=True,
                                 auto_delete=False,
                                 arguments={'x-queue-type': 'classic',
-                                            'x-message-ttl': 10 * 1000})
+                                           'x-message-ttl': 10 * 1000})
 
             _setup_exch_and_queue(self.channel, self._exch, self._queue)
         else:

--- a/python/idsse_common/idsse/common/rabbitmq_utils.py
+++ b/python/idsse_common/idsse/common/rabbitmq_utils.py
@@ -454,19 +454,23 @@ class Publisher(Thread):
         """
         Method that initializes the RabbitMQ connection, channel, exchange, and queue to be used
         to publish messages in a threadsafe way.
-        Can be overridden to customize how Publisher establishes these RMQ resources.
+
+        Automatically called when a new Publisher() is instantiated. Can be overridden by child
+        classes to customize how Publisher establishes these RMQ resources.
 
         Args:
-            rmq_args (Conn | None)
+            channel_args (Conn | pika.channel.Channel): either connection parameters (Conn)
+                to establish a new RabbitMQ connection and channel, or an existing, pre-connected
+                pika Channel. Raises ValueError if channel_args is not one of these types.
         """
-        if isinstance(channel_args, Channel):
-            # reuse the existing RabbitMQ Connection and Channel passed to setup()
-            self.connection = channel_args.connection
-            self.channel = channel_args
-        elif isinstance(channel_args, Conn):
+        if isinstance(channel_args, Conn):
             # create new RabbitMQ Connection and Channel using the provided params
             self.connection = BlockingConnection(channel_args.connection_parameters)
             self.channel = self.connection.channel()
+        elif isinstance(channel_args, Channel):
+            # reuse the existing RabbitMQ Connection and Channel passed to setup()
+            self.connection = channel_args.connection
+            self.channel = channel_args
         else:
             raise ValueError('Publisher expects RabbitMQ params (Conn) or existing Channel to run setup')
 

--- a/python/idsse_common/idsse/common/utils.py
+++ b/python/idsse_common/idsse/common/utils.py
@@ -117,7 +117,6 @@ def exec_cmd(commands: Sequence[str], timeout: int | None = None) -> Sequence[st
 
 def to_iso(date_time: datetime) -> str:
     """Format a datetime instance to an ISO string"""
-    logger.debug('Datetime (%s) to iso', datetime)
     return (f'{date_time.strftime("%Y-%m-%dT%H:%M")}:'
             f'{(date_time.second + date_time.microsecond / 1e6):06.3f}'
             'Z' if date_time.tzname() in [None, str(timezone.utc)]
@@ -126,7 +125,6 @@ def to_iso(date_time: datetime) -> str:
 
 def to_compact(date_time: datetime) -> str:
     """Format a datetime instance to a compact string"""
-    logger.debug('Datetime (%s) to compact -- %s', datetime, __name__)
     return date_time.strftime('%Y%m%d%H%M%S')
 
 

--- a/python/idsse_common/test/test_rabbitmq_utils.py
+++ b/python/idsse_common/test/test_rabbitmq_utils.py
@@ -245,7 +245,7 @@ def test_simple_publisher_existing_channel(
     monkeypatch.setattr('idsse.common.rabbitmq_utils.BlockingConnection', mock_blocking_connection)
     mock_channel.__class__ = Channel  # make mock look like real pika.Channel
 
-    publisher = Publisher(CONN, RMQ_PARAMS.exchange, channel=mock_channel)
+    publisher = Publisher(mock_channel, RMQ_PARAMS.exchange)
 
     mock_blocking_connection.assert_not_called()  # should not have created new Connection/Channel
     assert publisher.channel == mock_channel


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-897](https://linear.app/idss/issue/IDSSE-897)

### Changes
<!-- Brief description of changes -->
- Add optional `channel` kwarg to the RabbitMQ `Publisher` class to reuse an existing RabbitMQ channel
- Move Publisher connection/channel/exchange setup into a `setup()` method, so the behavior can be customized (overridden) by any theoretical future child classes.

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
This is step 1 of creating an `Rpc` class in rabbitmq_utils. [Direct reply-to](https://www.rabbitmq.com/docs/direct-reply-to#limitations) has to receive responses with the same RabbitMQ Connection and Channel that was used to send the original request, or the response message won't get routed correctly. 

This arg will give us an option to reuse a single Connection & Channel between a Publisher and Consumer instance, rather than Publishers and Consumers always making their own new channels. The vast majority of Publisher() instantiations won't use this optional arg.