### PR TITLE
add 'CREF' as accepted Field string

### DIFF
--- a/python/idsse_common/idsse/common/schema/field.json
+++ b/python/idsse_common/idsse/common/schema/field.json
@@ -29,7 +29,8 @@
           "VISIBILITY",
           "WINDDIR",
           "WINDGUST",
-          "WINDSPEED"
+          "WINDSPEED",
+          "CREF"
         ]
     },
 

--- a/python/idsse_common/idsse/common/schema/product.json
+++ b/python/idsse_common/idsse/common/schema/product.json
@@ -1,7 +1,7 @@
 {
     "Product": {
-        "description": "Identifier for supported products",
-        "type": "string",
-        "enum": ["NBM", "NBM.AWS", "NBM.AWS.GRIB"]
+      "description": "Identifier for supported products",
+      "type": "string",
+      "enum": ["NBM", "NBM.AWS", "NBM.AWS.GRIB", "MRMS"]
     }
 }


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-1076](https://linear.app/idss/issue/IDSSE-1076)

### Changes
<!-- Brief description of changes -->
- Add "MRMS" product and "CREF" field to their respective JSON schemas

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
DAS New Data service was publishing new data messages that were technically "invalid" for the product MRMS, so a service consuming these messages may reject it if they compared it against the jsonschema validator.
