### PR TITLE
Idsse 1066

### DIFF
--- a/python/idsse_common/idsse/common/rabbitmq_utils.py
+++ b/python/idsse_common/idsse/common/rabbitmq_utils.py
@@ -359,7 +359,6 @@ class Rpc:
 
         # send request to external RMQ service, providing the queue where it should respond
         properties = BasicProperties(content_type='application/json',
-                                     #correlation_id=request_id,
                                      headers={'rpc': request_id},
                                      reply_to=self._queue.name)
 
@@ -417,7 +416,6 @@ class Rpc:
                      method.routing_key, properties.content_type, str(body, encoding='utf-8'))
 
         # remove future from pending list. we will update result shortly
-        # request_future = self._pending_requests.pop(properties.correlation_id)
         request_future = self._pending_requests.pop(properties.headers['rpc'])
 
         # messages sent through RabbitMQ Direct reply-to are auto acked

--- a/python/idsse_common/test/test_rabbitmq_utils.py
+++ b/python/idsse_common/test/test_rabbitmq_utils.py
@@ -296,9 +296,9 @@ def test_send_request_works_without_calling_start(rpc_thread: Rpc,
     def mock_blocking_publish(*_args, **_kwargs):
         # build mock message from imaginary external service
         method = Method('', 123)
-        props = BasicProperties(content_type='application/json', correlation_id=EXAMPLE_UUID)
+        #props = BasicProperties(content_type='application/json', correlation_id=EXAMPLE_UUID)
+        props = BasicProperties(content_type='application/json', headers={'rpc': EXAMPLE_UUID})
         body = bytes(json.dumps(example_message), encoding='utf-8')
-
         rpc_thread._response_callback(mock_channel, method, props, body)
 
     monkeypatch.setattr('idsse.common.rabbitmq_utils._blocking_publish',

--- a/python/idsse_common/test/test_rabbitmq_utils.py
+++ b/python/idsse_common/test/test_rabbitmq_utils.py
@@ -296,7 +296,6 @@ def test_send_request_works_without_calling_start(rpc_thread: Rpc,
     def mock_blocking_publish(*_args, **_kwargs):
         # build mock message from imaginary external service
         method = Method('', 123)
-        #props = BasicProperties(content_type='application/json', correlation_id=EXAMPLE_UUID)
         props = BasicProperties(content_type='application/json', headers={'rpc': EXAMPLE_UUID})
         body = bytes(json.dumps(example_message), encoding='utf-8')
         rpc_thread._response_callback(mock_channel, method, props, body)


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-1066](https://linear.app/idss/issue/IDSSE-1066)

### Changes
<!-- Brief description of changes -->
- Update the use of UUID as a corelation_id in the  properties of a RMQ message request/respond actions for RPC. 

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
Initial implementation for consistent use o  correlation_id in RMQ messages