### PR TITLE
bug: AWS permission error when FileNotFound

### DIFF
--- a/python/idsse_common/idsse/common/aws_utils.py
+++ b/python/idsse_common/idsse/common/aws_utils.py
@@ -98,4 +98,3 @@ class AwsUtils(ProtocolUtils):
                 return False
             finally:
                 pass
-

--- a/python/idsse_common/idsse/common/aws_utils.py
+++ b/python/idsse_common/idsse/common/aws_utils.py
@@ -96,3 +96,5 @@ class AwsUtils(ProtocolUtils):
                 return False
             finally:
                 pass
+        except PermissionError:
+            return False

--- a/python/idsse_common/idsse/common/aws_utils.py
+++ b/python/idsse_common/idsse/common/aws_utils.py
@@ -86,6 +86,8 @@ class AwsUtils(ProtocolUtils):
 
             exec_cmd(commands)
             return True
+        except PermissionError:
+            return False  # in s5cmd, this means 404 FileNotFound; don't bother retrying with aws-cli
         except FileNotFoundError:
             try:
                 logger.debug('Second attempt with aws command line')
@@ -96,5 +98,4 @@ class AwsUtils(ProtocolUtils):
                 return False
             finally:
                 pass
-        except PermissionError:
-            return False
+

--- a/python/idsse_common/test/test_aws_utils.py
+++ b/python/idsse_common/test/test_aws_utils.py
@@ -133,24 +133,23 @@ def test_cp_retries_with_s3_command_line(aws_utils: AwsUtils, monkeypatch: Monke
 
 
 def test_cp_permissions_error(aws_utils: AwsUtils, monkeypatch: MonkeyPatch):
-    mock_exec_cmd_failure = Mock(
-        side_effect=PermissionError)
-    monkeypatch.setattr('idsse.common.aws_utils.exec_cmd',
-                        mock_exec_cmd_failure)
+    mock_exec_cmd_failure = Mock(side_effect=PermissionError)
+    monkeypatch.setattr('idsse.common.aws_utils.exec_cmd', mock_exec_cmd_failure)
 
     copy_success = aws_utils.cp('s3:/some/path', 's3:/new/path')
+
     assert not copy_success
-    # should not re-attempt with s3; s5cmd PermissionError means 404 FileNotFound
+    # s5cmd throws PermissionError when file not found in AWS; don't bother retrying with aws-cli
     assert mock_exec_cmd_failure.call_count == 1
 
 
 def test_cp_fails(aws_utils: AwsUtils, monkeypatch: MonkeyPatch):
-    mock_exec_cmd_failure = Mock(
-        side_effect=[FileNotFoundError, Exception('unexpected bad thing happened')])
-    monkeypatch.setattr('idsse.common.aws_utils.exec_cmd',
-                        mock_exec_cmd_failure)
+    mock_exec_cmd_failure = Mock(side_effect=[FileNotFoundError,
+                                              Exception('unexpected bad thing happened')])
+    monkeypatch.setattr('idsse.common.aws_utils.exec_cmd', mock_exec_cmd_failure)
 
     copy_success = aws_utils.cp('s3:/some/path', 's3:/new/path')
+
     assert not copy_success
     assert mock_exec_cmd_failure.call_count == 2
 

--- a/python/idsse_common/test/test_aws_utils.py
+++ b/python/idsse_common/test/test_aws_utils.py
@@ -132,6 +132,18 @@ def test_cp_retries_with_s3_command_line(aws_utils: AwsUtils, monkeypatch: Monke
     assert mock_exec_cmd_failure.call_count == 2
 
 
+def test_cp_permissions_error(aws_utils: AwsUtils, monkeypatch: MonkeyPatch):
+    mock_exec_cmd_failure = Mock(
+        side_effect=PermissionError)
+    monkeypatch.setattr('idsse.common.aws_utils.exec_cmd',
+                        mock_exec_cmd_failure)
+
+    copy_success = aws_utils.cp('s3:/some/path', 's3:/new/path')
+    assert not copy_success
+    # should not re-attempt with s3; not an s5cmd problem
+    assert mock_exec_cmd_failure.call_count == 1
+
+
 def test_cp_fails(aws_utils: AwsUtils, monkeypatch: MonkeyPatch):
     mock_exec_cmd_failure = Mock(
         side_effect=[FileNotFoundError, Exception('unexpected bad thing happened')])

--- a/python/idsse_common/test/test_aws_utils.py
+++ b/python/idsse_common/test/test_aws_utils.py
@@ -140,7 +140,7 @@ def test_cp_permissions_error(aws_utils: AwsUtils, monkeypatch: MonkeyPatch):
 
     copy_success = aws_utils.cp('s3:/some/path', 's3:/new/path')
     assert not copy_success
-    # should not re-attempt with s3; not an s5cmd problem
+    # should not re-attempt with s3; s5cmd PermissionError means 404 FileNotFound
     assert mock_exec_cmd_failure.call_count == 1
 
 


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-1124](https://linear.app/idss/issue/IDSSE-1124)

### Changes
<!-- Brief description of changes -->
- Catch PermissionError from s5cmd `cp()` and consider the copy failed

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
Example error from the logs:
```
PermissionError: [Errno 1] ERROR ['cp', 
  's3://noaa-nbm-grib2-pds/blend.20250212/21/core/blend.t21z.core.f015.co.grib2.idx',
  '/local_data/tmp/NBM.AWS.GRIB/CONUS/2025/02/12/NBM.AWS.GRIB_CONUS_20250212210000_20250213120000.grib2.idx"'] \
  : NoSuchKey: The specified key does not exist. status code: 404, request id: 6RK36H29SDDK1FPD, host id: qHKluGgOENa7M3mpA95CI7cGQQ6TOGyfD6098UNTcf5mH2uSC2QkpGLZiNR8dyXeEhw26djYa7A=
```

This 404 means the file we tried to download doesn't exist in the S3 bucket (yet). By returning False, we can allow function callers to retry, rather than throwing an uncaught exception. 

DAS [already has retry logic](https://github.com/NOAA-GSL/data-access-service/blob/ccde98e19742a1d9285b661387895286e1470d82/python/das/data_retrieval/src/data_retrieval/product_getters/aws_grib_reader.py#L266-L272), but it wasn't triggered because this function would explode instead of return a boolean.