### PR TITLE
bug: field.json schema DewPoint

### DIFF
--- a/python/idsse_common/idsse/common/schema/field.json
+++ b/python/idsse_common/idsse/common/schema/field.json
@@ -8,7 +8,7 @@
           "CEILING",
           "Ceiling",
           "DEWPOINT",
-          "Dewpoint",
+          "DewPoint",
           "ECHOTOP",
           "EchoTop",
           "ICE1HR",


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-1124](https://linear.app/idss/issue/IDSSE-1124)

### Changes
<!-- Brief description of changes -->
- Change the field.json schema (used by New Data) to allow the string `DewPoint`, which matches other DAS constants (not `Dewpoint`)
 
### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
N/A