### PR TITLE
bug: idsse-1135: Consumer callbacks not logging

### DIFF
--- a/python/idsse_common/test/test_rabbitmq_utils.py
+++ b/python/idsse_common/test/test_rabbitmq_utils.py
@@ -299,7 +299,8 @@ def test_send_request_works_without_calling_start(rpc_thread: Rpc,
         method = Method('', 123)
         props = BasicProperties(content_type='application/json', headers={'rpc': EXAMPLE_UUID})
         body = bytes(json.dumps(example_message), encoding='utf-8')
-        rpc_thread.on_response(mock_channel, method, props, body)
+        # pylint: disable=protected-access
+        rpc_thread._on_response(mock_channel, method, props, body)
 
     monkeypatch.setattr('idsse.common.rabbitmq_utils._blocking_publish',
                         Mock(side_effect=mock_blocking_publish))
@@ -350,7 +351,8 @@ def test_nacks_unrecognized_response(rpc_thread: Rpc,
     props = BasicProperties(content_type='application/json', headers={'rpc': 'unknown_id'})
     body = bytes(json.dumps({'data': 123}), encoding='utf-8')
 
-    rpc_thread.on_response(mock_channel, Method(delivery_tag=delivery_tag), props, body)
+    # pylint: disable=protected-access
+    rpc_thread._on_response(mock_channel, Method(delivery_tag=delivery_tag), props, body)
 
     # unregistered message was nacked
     mock_channel.basic_nack.assert_called_with(delivery_tag=delivery_tag, requeue=False)


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-1135](https://linear.app/idss/issue/IDSSE-1135)

### Changes
<!-- Brief description of changes -->
- `Consumer`: copy `context` of Consumer to any ThreadPoolExecutor threads
  - Previously, no log messages from Consumer `on_message` callbacks were making it to the console due to this bug, except calls to functions like `threadsafe_ack()`.
- `rabbitmq_utils.Rpc`: nack any response message that can't be correlated with a request based on `properties.headers.rpc`
  - This quirk where RPC silently ignores any "unregistered" response message hid [a bug in DAS](https://github.com/NOAA-GSL/data-access-service/pull/144). We figured it out, but this logging will surface issues like that sooner.

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
N/A