### PR TITLE
chore: RpcPublisher and RpcConsumer classes

### DIFF
--- a/python/idsse_common/idsse/common/rabbitmq_rpc.py
+++ b/python/idsse_common/idsse/common/rabbitmq_rpc.py
@@ -1,0 +1,244 @@
+"""Module for RPC (remote prodedure call, a.k.a. call-and-response) type RabbitMQ communication"""
+# ----------------------------------------------------------------------------------
+# Created on Thu Feb 27 2025
+#
+# Copyright (c) 2025 Colorado State University. All rights reserved. (1)
+#
+# Contributors:
+#     Mackenzie Grimes (1)
+#
+# ----------------------------------------------------------------------------------
+import logging
+import logging.config
+import uuid
+from collections.abc import Callable
+from concurrent.futures import Future
+from copy import deepcopy
+from typing import NamedTuple
+
+from pika.channel import Channel
+from pika.spec import Basic, BasicProperties
+
+from .rabbitmq_utils import (Conn,
+                             Consumer,
+                             Exch,
+                             RabbitMqParams,
+                             RabbitMqParamsAndCallback,
+                             Rpc, RabbitMqMessage,
+                             threadsafe_ack,
+                             threadsafe_nack,
+                             blocking_publish)
+
+logger = logging.getLogger(__name__)
+
+
+class RpcResponse(NamedTuple):
+    """Data class to specify how result of RPC request should be communicated to the RMQ broker.
+    Either ack or nack with no requeue (usually a response RabbitMqMessage should be published),
+    or nack with requeue True (to re-attempt processing).
+
+    Message can be None (and is None by default), meaning request is only acked/nacked without
+    a response to the awaiting requestor, but this should generally only be used if requeue=True.
+    """
+    message: RabbitMqMessage | None
+    ack: bool = True
+    requeue: bool = False
+
+
+# Tech debt: this is a temporary class "alias" to Rpc to match naming convention of
+# `RpcConsumer`. Will be deleted (and `Rpc` renamed) after current usages of `Rpc` are migrated
+class RpcPublisher(Rpc):
+    """RabbitMQ RPC (remote procedure call) publishing client, runs in own thread to not block
+    heartbeat. This class can be used to send "requests" (outbound messages) over RabbitMQ and
+    block until a "response" (inbound message) comes back from an `RpcConsumer` instance.
+    All producing to/consuming of different queues and associating requests with their responses
+    is abstracted away.
+
+    By RabbitMQ convention, RPC uses the built-in Direct Reply-To queue to field responses messages,
+    which generates a temporary, random queue name for that individual message, rather than
+    creating its own durable queue. Directing responses to a custom queue is not yet supported.
+
+    The `start()` and `stop()` methods should be called from the same thread that created the
+    `RpcPublisher` instance.
+
+    Example usage:
+        ```
+        my_client = RpcPublisher(...insert RabbitMQ parameters...)
+        my_client.start()
+
+        response = my_client.send_message(RabbitMqMessage('{"some": "json"}'))
+        # blocks while waiting for response
+        logger.info(f'Got response from external service: {response}')
+        ```
+    """
+    # pylint: disable=arguments-renamed
+    def send_request(self, request: RabbitMqMessage) -> RabbitMqMessage | None:
+        """Send message to remote RabbitMQ service using thread-safe RPC. Will block until response
+        is received back, or timeout occurs.
+
+        Args:
+            request (RabbitMqMessage): the RabbitMQ message body and (optional) properties to send
+                as a "request" to the listening RpcConsumer service.
+
+        Returns:
+            RabbitMqMessage | None: The response message (body and properties), or None on request
+                timeout or error handling response.
+        """
+        if not self.is_open:
+            logger.debug('RPC thread not yet initialized. Setting up now')
+            self.start()
+
+        # generate unique ID to associate our request to external service's response
+        request_id = str(uuid.uuid4())
+
+        # send request to external RMQ service, providing unique RPC message ID and
+        # the queue where it should respond
+        if request.properties.headers is None:
+            request.properties.headers = {}
+        request.properties.headers['rpc'] = request_id
+        request.properties.reply_to = self._queue.name
+
+        # overwrite routing key (if any) to enforce use of default Exchange and Direct Reply-to
+        request = RabbitMqMessage(request.body, request.properties, self._exch.route_key)
+
+        # add future to dict where callback can retrieve it and set result
+        request_future = Future()
+        self._pending_requests[request_id] = request_future
+
+        logger.debug('Publishing request message to external service with body: %s', request.body)
+        blocking_publish(self._consumer.channel,
+                          self._exch,
+                          request,
+                          self._queue)
+
+        try:
+            # block until callback runs (we'll know when the future's result has been changed)
+            return request_future.result(timeout=self._timeout)
+        except TimeoutError:
+            logger.warning('Timed out waiting for response. rpc request_id: %s', request_id)
+            self._pending_requests.pop(request_id)  # stop tracking request Future
+            return None
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.warning('Unexpected response from external service: %s', str(exc))
+            self._pending_requests.pop(request_id)  # stop tracking request Future
+            return None
+
+
+class RpcConsumer():
+    """Consumer RPC (remote prodecure call) class that serves as the listener to `RpcPublisher`
+    messages. `RpcConsumer` creates a thread to constantly consume RPC message "requests" emitted
+    by `RpcPublisher`, form a response, and send back it to the `RpcPublisher` asynchronously.
+
+    Note that RPC by RabbitMQ convention uses built-in Direct Reply-to queue over the default
+    exchange, and listeners for responses on a temporary queue unique to a given RPC request.
+    Publishing RpcConsumer responses to a custom, durable queue is not yet supported.
+
+    Example usage:
+        ```
+        def on_receive_request(message: RabbitMqMessage):
+            logger.info('Got request from external service: %s', message.body)
+            if message.properties.content_type == 'application/json':
+                return RpcResponse(RabbitMqMessage('success!'), ack=True)
+            return RpcResponse(None, ack=False, requeue=True)
+
+        my_consumer = RpcConsumer(<insert Conn>,
+                                  RmqParams(<insert Exch>, <insert Queue>),
+                                  on_receive_request)
+        my_consumer.start()
+        ```
+    """
+    def __init__(self,
+                 conn_params: Conn,
+                 rmq_params: RabbitMqParams,
+                 on_request_callback: Callable[[RabbitMqMessage], RpcResponse],
+                 *args,
+                 **kwargs):
+        """
+        Args:
+            conn_params (Conn): parameters to connect to RabbitMQ server
+            rmq_params (RabbitMqParams): parameters of RMQ Exchange and Queue where RPC messages
+                are expected to be received from an `RpcPublisher`.
+            on_message_callback (Callable[[RabbitMqMesssage], RpcResponse]): a function that
+                receives an inbound RPC request message, does some work with it, then returns a
+                RpcResponse, which controls if message should be acked/nacked and some
+                RabbitMqMessage published back the original requester, or if the request
+                should be nack'd and requeued to re-attempt processing
+        """
+        self._rmq_params = rmq_params
+        self._on_request_callback = on_request_callback
+
+        # Start long-running thread to consume any messages from response queue
+        self._consumer = Consumer(conn_params,
+                                  RabbitMqParamsAndCallback(rmq_params, self._on_message),
+                                  *args,
+                                  **kwargs)
+
+    @property
+    def is_open(self):
+        """Returns True if RabbitMQ connection (Consumer) is open and ready to receive messages"""
+        return self._consumer.is_alive() and self._consumer.channel.is_open
+
+    def start(self):
+        """Start dedicated threads to asynchronously receive, and send, RPC messages using a new
+        RabbitMQ connection and channel. Note: this method can be called externally, but it is
+        not required to use the client. It will automatically call this internally as needed."""
+        if not self.is_open:
+            logger.debug('Starting RPC thread to consume messages')
+            self._consumer.start()
+            self._consumer.join()
+
+    def stop(self):
+        """Unsubscribe to queue and cleanup thread(s)"""
+        logger.debug('Shutting down RpcConsumer threads')
+        if not self.is_open:
+            logger.debug('RpcConsumer threads not running, nothing to cleanup')
+            return
+
+        # tell Consumer to cleanup RabbitMQ resources and wait for thread to terminate
+        self._consumer.stop()
+        self._consumer.join()
+
+    def _on_message(self,
+                    channel: Channel,
+                    method: Basic.Deliver,
+                    properties: BasicProperties,
+                    body: bytes):
+        """Handle receiving a request message from an `RpcPublisher`. Invoke user-provided callback
+        to form response body, then send RabbitMQ message over Exchange (likely default) and Queue
+        (likely a unique Direct Reply-to) that `RpcPublisher` specified in message props.
+        """
+        request = body.decode()
+        logger.debug('Received request message from external message with body: %s', request)
+        response = self._on_request_callback(RabbitMqMessage(request, properties,
+                                                             method.routing_key))
+
+        if response.ack:
+            threadsafe_ack(channel,
+                           method.delivery_tag,
+                           lambda: logger.debug('Request %s was acked',
+                                                properties.headers.get('rpc')))
+        else:
+            threadsafe_nack(channel,
+                            method.delivery_tag,
+                            lambda: logger.debug('Request %s was nacked',
+                                                 properties.headers.get('rpc')),
+                            requeue=response.requeue)
+
+        if content := response.message:
+            # per RabbitMQ RPC convention, always use default Exchange so clients can operate on
+            # any exchange and RabbitMQ will route the message to their queue correctly
+            exch = Exch('', 'direct', route_key=properties.reply_to)
+            logger.info('Publishing response to default exchange, routing key: %s', exch.route_key)
+            logger.debug('Publishing response to external request service: %s', content.body)
+
+            # tag this response message using the "rpc" UUID from request's headers; required so
+            # RpcPublisher can associate each request/response pair and resolve all pending Futures
+            response_props = deepcopy(content.properties)
+            response_props.reply_to = properties.reply_to
+            if response_props.headers is None:
+                response_props.headers = {}
+            response_props.headers['rpc'] = properties.headers.get('rpc')
+
+            blocking_publish(channel,
+                              exch,
+                              RabbitMqMessage(content.body, response_props, exch.route_key))

--- a/python/idsse_common/idsse/common/rabbitmq_rpc.py
+++ b/python/idsse_common/idsse/common/rabbitmq_rpc.py
@@ -71,7 +71,7 @@ class RpcPublisher(Rpc):
         logger.info(f'Got response from external service: {response}')
         ```
     """
-    # pylint: disable=arguments-renamed
+    # pylint: disable=arguments-renamed,duplicate-code
     def send_request(self, request: RabbitMqMessage) -> RabbitMqMessage | None:
         """Send message to remote RabbitMQ service using thread-safe RPC. Will block until response
         is received back, or timeout occurs.

--- a/python/idsse_common/idsse/common/rabbitmq_utils.py
+++ b/python/idsse_common/idsse/common/rabbitmq_utils.py
@@ -344,7 +344,7 @@ class Rpc:
         """Returns True if RabbitMQ connection (Publisher) is open and ready to send messages"""
         return self._consumer.is_alive() and self._consumer.channel.is_open
 
-    def send_request(self, request_body: str | bytes) -> RabbitMqMessage | None:
+    def send_request(self, request_body: str | bytes) -> RabbitMqMessage | None:  # pragma: no cover
         """Send message to remote RabbitMQ service using thread-safe RPC. Will block until response
         is received back, or timeout occurs.
 
@@ -609,9 +609,9 @@ class RpcConsumer():
 
         if response.ack:
             threadsafe_ack(channel,
-                              method.delivery_tag,
-                              lambda: logger.debug('Request %s was acked',
-                                                   properties.headers.get('rpc')))
+                           method.delivery_tag,
+                           lambda: logger.debug('Request %s was acked',
+                                                properties.headers.get('rpc')))
         else:
             threadsafe_nack(channel,
                             method.delivery_tag,
@@ -841,7 +841,6 @@ def _initialize_connection_and_channel(
         _channel = channel
 
     queue_name = _initialize_exchange_and_queue(_channel, params)
-
     return _connection, _channel, queue_name
 
 

--- a/python/idsse_common/idsse/common/rabbitmq_utils.py
+++ b/python/idsse_common/idsse/common/rabbitmq_utils.py
@@ -17,7 +17,6 @@ import uuid
 
 from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
-from copy import deepcopy
 from functools import partial
 from threading import Event, Thread
 from typing import NamedTuple

--- a/python/idsse_common/idsse/common/rabbitmq_utils.py
+++ b/python/idsse_common/idsse/common/rabbitmq_utils.py
@@ -465,10 +465,12 @@ class RpcPublisher(Rpc):
     """
     # pylint: disable=arguments-renamed
     def send_request(self, request: RabbitMqMessage) -> RabbitMqMessage | None:
-        """_summary_
+        """Send message to remote RabbitMQ service using thread-safe RPC. Will block until response
+        is received back, or timeout occurs.
 
         Args:
-            request (RabbitMqMessage): _description_
+            request (RabbitMqMessage): the RabbitMQ message body and (optional) properties to send
+                as a "request" to the listening RpcConsumer service.
 
         Returns:
             RabbitMqMessage | None: The response message (body and properties), or None on request

--- a/python/idsse_common/test/test_rabbitmq_rpc.py
+++ b/python/idsse_common/test/test_rabbitmq_rpc.py
@@ -9,7 +9,7 @@
 #
 # ------------------------------------------------------------------------------
 # pylint: disable=missing-function-docstring,missing-class-docstring,too-few-public-methods
-# pylint: disable=redefined-outer-name,unused-argument,protected-access
+# pylint: disable=redefined-outer-name,unused-argument,protected-access,duplicate-code
 import json
 from typing import NamedTuple
 from unittest.mock import Mock

--- a/python/idsse_common/test/test_rabbitmq_rpc.py
+++ b/python/idsse_common/test/test_rabbitmq_rpc.py
@@ -1,0 +1,273 @@
+"""Testing for RabbitMqUtils functions"""
+# ------------------------------------------------------------------------------
+# Created on Thu Feb 27 2025
+#
+# Copyright (c) 2025 Colorado State University. All rights reserved. (1)
+#
+# Contributors:
+#     Mackenzie Grimes (1)
+#
+# ------------------------------------------------------------------------------
+# pylint: disable=missing-function-docstring,missing-class-docstring,too-few-public-methods
+# pylint: disable=redefined-outer-name,unused-argument,protected-access
+import json
+from typing import NamedTuple
+from unittest.mock import Mock
+from uuid import UUID
+
+from pytest import fixture, MonkeyPatch
+from pika import BasicProperties, BlockingConnection
+from pika.adapters.blocking_connection import BlockingChannel
+
+from idsse.common.rabbitmq_utils import DIRECT_REPLY_QUEUE, Queue
+from idsse.common.rabbitmq_rpc import (Conn, Consumer, Exch, Future, RabbitMqParams,
+                                       RabbitMqMessage, RpcConsumer, RpcPublisher, RpcResponse)
+
+
+# Example data objects
+CONN = Conn('localhost', '/', port=5672, username='user', password='password')
+RMQ_PARAMS = RabbitMqParams(
+    Exch('test_criteria_exch', 'topic'),
+    Queue('test_criteria_queue', '', True, False, True)
+)
+EXAMPLE_UUID = 'b6591cc7-8b33-4cd3-aa22-408c83ac5e3c'
+
+
+class Method(NamedTuple):
+    """Mock of pika.frame.Method"""
+    exchange: str = ' '
+    queue: str = ''
+    delivery_tag: int = 0
+    routing_key: str = ''
+
+
+class Frame(NamedTuple):
+    """Mock of pika.frame.Frame"""
+    method: Method
+
+
+# fixtures
+@fixture
+def mock_channel() -> Mock:
+    """Mock pika.adapters.blocking_connection.BlockingChannel object"""
+    def mock_queue_declare(queue: str, **_kwargs) -> Method:
+        return Frame(Method(queue=queue))  # create a usable (mock) Frame using queue name passed
+    def mock_exch_declare(exchange: str, **_kwargs) -> Method:
+        return Frame(Method(exchange=exchange))
+
+    mock_obj = Mock(spec=BlockingChannel, name='MockChannel')
+    mock_obj.exchange_declare = Mock(side_effect=mock_exch_declare)
+    mock_obj.queue_declare = Mock(side_effect=mock_queue_declare)
+    mock_obj.is_open = True
+    return mock_obj
+
+
+@fixture
+def mock_connection(mock_channel: Mock) -> Mock:
+    """Mock pika.BlockingChannel object"""
+    mock_obj = Mock(spec=BlockingConnection, name='MockConnection')
+    mock_obj.channel = Mock(return_value=mock_channel)
+    return mock_obj
+
+
+@fixture
+def mock_consumer(monkeypatch: MonkeyPatch, mock_connection: Mock, mock_channel: Mock) -> Mock:
+    """Mock rabbitmq_utils.Consumer thread instance"""
+    mock_obj = Mock(spec=Consumer, name='MockConsumer')
+    mock_obj.return_value.is_alive = Mock(return_value=False)  # by default, thread not running
+    mock_obj.return_value.connection = mock_connection
+    mock_obj.return_value.channel = mock_channel
+    # hack pika add_callback_threadsafe to invoke immediately (hides complexity of threading)
+    mock_obj.return_value.channel.connection.add_callback_threadsafe = Mock(
+        side_effect=lambda cb: cb()
+    )
+
+    monkeypatch.setattr('idsse.common.rabbitmq_rpc.Consumer', mock_obj)
+    # temporarily need to mock Consumer out of rabbitmq_utils as well, where deprecated Rpc is
+    monkeypatch.setattr('idsse.common.rabbitmq_utils.Consumer', mock_obj)
+    return mock_obj
+
+
+@fixture
+def mock_uuid(monkeypatch: MonkeyPatch) -> Mock:
+    """Always return our example UUID str when UUID() is called"""
+    mock_obj = Mock()
+    mock_obj.UUID = Mock(side_effect=lambda: UUID(EXAMPLE_UUID))
+    mock_obj.uuid4 = Mock(side_effect=lambda: EXAMPLE_UUID)
+    monkeypatch.setattr('idsse.common.rabbitmq_rpc.uuid', mock_obj)
+    return mock_obj
+
+
+@fixture
+def rpc_thread(mock_consumer: Mock, mock_uuid: Mock) -> RpcPublisher:
+    return RpcPublisher(CONN, RMQ_PARAMS.exchange, timeout=5)
+
+
+# tests
+def test_rpc_opens_new_connection_and_channel(rpc_thread: RpcPublisher, mock_consumer: Mock):
+    assert not rpc_thread.is_open
+    rpc_thread.start()
+
+    mock_consumer.return_value.start.assert_called_once()
+    mock_consumer.return_value.is_alive = Mock(return_value=True)  # Consumer thread would be live
+
+    # stop Rpc client and confirm that Consumer thread was closed
+    rpc_thread.stop()
+    mock_consumer.return_value.is_alive = Mock(return_value=False)  # Consumer thread would be dead
+
+    assert not rpc_thread.is_open
+
+    mock_consumer.return_value.stop.assert_called_once()
+    mock_consumer.return_value.join.assert_called_once()
+
+
+def test_stop_does_nothing_if_not_started(rpc_thread: RpcPublisher, mock_consumer: Mock):
+    # calling stop before starting does nothing
+    rpc_thread.stop()
+    mock_consumer.stop.assert_not_called()
+
+    rpc_thread.start()
+    mock_consumer.return_value.is_alive = Mock(return_value=True)  # Consumer thread would be live
+
+    # calling start when already running does nothing
+    mock_consumer.reset_mock()
+    rpc_thread.start()
+    mock_consumer.return_value.start.assert_not_called()
+
+
+def test_send_request_works_without_calling_start(rpc_thread: RpcPublisher,
+                                                  mock_channel: Mock,
+                                                  mock_connection: Mock,
+                                                  mock_consumer: Mock,
+                                                  monkeypatch: MonkeyPatch):
+    example_message = {'value': 'hello world'}
+
+    # when client calls blocking_publish, manually invoke response callback with a faked message
+    # from external service, simulating RMQ call/response
+    def mock_blocking_publish(*_args, **_kwargs):
+        # build mock message from imaginary external service
+        method = Method('', 123)
+        props = BasicProperties(content_type='application/json', headers={'rpc': EXAMPLE_UUID})
+        body = bytes(json.dumps(example_message), encoding='utf-8')
+        rpc_thread._on_response(mock_channel, method, props, body)
+
+    monkeypatch.setattr('idsse.common.rabbitmq_rpc.blocking_publish',
+                        Mock(side_effect=mock_blocking_publish))
+
+    result = rpc_thread.send_request(RabbitMqMessage(json.dumps({'fake': 'request message'})))
+    assert json.loads(result.body) == example_message
+
+
+def test_send_request_times_out_if_no_response(mock_connection: Mock,
+                                               mock_consumer: Mock,
+                                               mock_uuid: Mock,
+                                               monkeypatch: MonkeyPatch):
+    # create client with same parameters, except a very short timeout
+    _thread = RpcPublisher(CONN, RMQ_PARAMS.exchange, timeout=0.01)
+
+    # do nothing on message publish
+    monkeypatch.setattr('idsse.common.rabbitmq_rpc.blocking_publish',
+                        Mock(side_effect=lambda *_args, **_kwargs: None))
+
+    result = _thread.send_request(RabbitMqMessage(json.dumps({'data': 123})))
+    assert EXAMPLE_UUID not in _thread._pending_requests  # request was cleaned up
+    assert result is None
+
+
+def test_send_requests_returns_none_on_error(rpc_thread: RpcPublisher, mock_channel: Mock):
+    # pylint: disable=too-many-arguments
+    def mock_basic_publish(exchange, routing_key, body, properties = None, mandatory = False):
+        # cause exception for pending request Future
+        rpc_thread._pending_requests[EXAMPLE_UUID].set_exception(RuntimeError('Something broke'))
+    mock_channel.basic_publish.side_effect = mock_basic_publish
+
+    result = rpc_thread.send_request(RabbitMqMessage({'data': 123}))
+
+    assert EXAMPLE_UUID not in rpc_thread._pending_requests  # request was cleaned up
+    assert result is None
+
+
+def test_nacks_unrecognized_response(rpc_thread: RpcPublisher,
+                                     mock_connection: Mock,
+                                     mock_channel: Mock,
+                                     monkeypatch: MonkeyPatch):
+    rpc_thread._pending_requests = {'abcd': Future()}
+    delivery_tag = 123
+    props = BasicProperties(content_type='application/json', headers={'rpc': 'unknown_id'})
+    body = bytes(json.dumps({'data': 123}), encoding='utf-8')
+
+    rpc_thread._on_response(mock_channel, Method(delivery_tag=delivery_tag), props, body)
+
+    # unregistered message was nacked
+    mock_channel.basic_nack.assert_called_with(delivery_tag=delivery_tag, requeue=False)
+    # pending requests inside Rpc was not touched
+    assert 'abcd' in rpc_thread._pending_requests
+    assert not rpc_thread._pending_requests['abcd'].done()
+
+
+def test_send_request_preserves_props(rpc_thread: RpcPublisher, mock_channel: Mock):
+    # pylint: disable=too-many-arguments
+    def mock_basic_publish(exchange, routing_key, body, properties = None, mandatory = False):
+        # cause exception for pending request Future
+        rpc_thread._pending_requests[EXAMPLE_UUID].set_exception(RuntimeError('Something broke'))
+    mock_channel.basic_publish.side_effect = mock_basic_publish
+
+    result = rpc_thread.send_request(RabbitMqMessage({'data': 123}))
+
+    assert EXAMPLE_UUID not in rpc_thread._pending_requests  # request was cleaned up
+    assert result is None
+
+
+def test_rpc_consumer_start_stop(mock_consumer: Mock):
+    mock_consumer.return_value.is_alive.return_value = False
+    rpc_consumer = RpcConsumer(CONN, RMQ_PARAMS, lambda: None)
+
+    rpc_consumer.start()
+    mock_consumer.return_value.start.assert_called_once()
+
+    mock_consumer.return_value.is_alive.return_value = True
+
+    rpc_consumer.stop()
+    mock_consumer.return_value.stop.assert_called_once()
+
+
+def test_rpc_consumer_on_message_ack(mock_channel: Mock, mock_consumer: Mock):
+    example_response = RabbitMqMessage('{"response": "bar"}',
+                                       BasicProperties(content_type='application/json',
+                                                       correlation_id='some-correlation-id'))
+    mock_on_request = Mock(return_value=RpcResponse(example_response, ack=True))
+    inbound_tag = 7
+    inbound_rpc_id = '123'
+    inbound_reply_to = f'{DIRECT_REPLY_QUEUE}.g1h2AA5yZXBseUA1NTQ3NDU0OQAWaZUAAAAAZ7FK9g=='
+    inbound_props = BasicProperties(content_type='text/html',
+                                    headers={'rpc': inbound_rpc_id},
+                                    reply_to=inbound_reply_to)
+    inbound_body = bytes('{"request": "foo"}', encoding='utf-8')
+    rpc_consumer = RpcConsumer(CONN, RMQ_PARAMS, mock_on_request)
+
+    rpc_consumer._on_message(mock_channel, Method('', '', inbound_tag), inbound_props, inbound_body)
+
+    mock_channel.basic_ack.assert_called_once_with(inbound_tag)
+    assert mock_channel.basic_publish.call_count == 1
+    published_args = mock_channel.basic_publish.call_args[1]
+    assert published_args['body'] == example_response.body
+    assert published_args['properties'].reply_to == inbound_reply_to
+    assert published_args['properties'].content_type == 'application/json'
+    assert published_args['properties'].correlation_id == 'some-correlation-id'
+    assert published_args['properties'].headers['rpc'] == inbound_rpc_id
+
+
+def test_rpc_consumer_on_message_nack(mock_channel: Mock, mock_consumer: Mock):
+    example_response = RabbitMqMessage('{"response": "bar"}',
+                                       BasicProperties(content_type='application/json'))
+    mock_on_request = Mock(return_value=RpcResponse(example_response, ack=False, requeue=True))
+    inbound_tag = 7
+    inbound_props = BasicProperties(content_type='application/json',
+                                    headers={'rpc': '123'},
+                                    reply_to=DIRECT_REPLY_QUEUE)
+    inbound_body = bytes('{"request": "foo"}', encoding='utf-8')
+    rpc_consumer = RpcConsumer(CONN, RMQ_PARAMS, mock_on_request)
+
+    rpc_consumer._on_message(mock_channel, Method('', '', inbound_tag), inbound_props, inbound_body)
+
+    mock_channel.basic_nack.assert_called_once_with(inbound_tag, requeue=True)

--- a/python/idsse_common/test/test_rabbitmq_utils.py
+++ b/python/idsse_common/test/test_rabbitmq_utils.py
@@ -10,24 +10,21 @@
 #
 # ------------------------------------------------------------------------------
 # pylint: disable=missing-function-docstring,missing-class-docstring,too-few-public-methods
-# pylint: disable=redefined-outer-name,unused-argument,duplicate-code,protected-access
-import json
+# pylint: disable=redefined-outer-name,unused-argument,protected-access
 from threading import Event
 from typing import NamedTuple
 from unittest.mock import MagicMock, Mock, patch, ANY
-from uuid import UUID
 
 from pytest import fixture, raises, MonkeyPatch
-from pika import BasicProperties, BlockingConnection
+from pika import BlockingConnection
 from pika.adapters.blocking_connection import BlockingChannel
 from pika.exceptions import UnroutableError
 
-from idsse.common.rabbitmq_utils import (
-    DIRECT_REPLY_QUEUE, Conn, Consumer, Exch, Future, Queue, Publisher, RabbitMqParams,
-    RabbitMqParamsAndCallback, RabbitMqMessage, RpcConsumer, RpcPublisher, RpcResponse,
-    subscribe_to_queue, _publish, _setup_exch_and_queue, threadsafe_call, threadsafe_ack,
-    threadsafe_nack
-)
+from idsse.common.rabbitmq_utils import (Conn, Consumer, Exch, Queue, Publisher, RabbitMqParams,
+                                         RabbitMqParamsAndCallback, RabbitMqMessage,
+                                         subscribe_to_queue, _publish, _setup_exch_and_queue,
+                                         threadsafe_call, threadsafe_ack, threadsafe_nack)
+
 
 # Example data objects
 CONN = Conn('localhost', '/', port=5672, username='user', password='password')
@@ -73,37 +70,6 @@ def mock_connection(mock_channel: Mock) -> Mock:
     mock_obj = Mock(spec=BlockingConnection, name='MockConnection')
     mock_obj.channel = Mock(return_value=mock_channel)
     return mock_obj
-
-
-@fixture
-def mock_consumer(monkeypatch: MonkeyPatch, mock_connection: Mock, mock_channel: Mock) -> Mock:
-    """Mock rabbitmq_utils.Consumer thread instance"""
-    mock_obj = Mock(spec=Consumer, name='MockConsumer')
-    mock_obj.return_value.is_alive = Mock(return_value=False)  # by default, thread not running
-    mock_obj.return_value.connection = mock_connection
-    mock_obj.return_value.channel = mock_channel
-    # hack pika add_callback_threadsafe to invoke immediately (hides complexity of threading)
-    mock_obj.return_value.channel.connection.add_callback_threadsafe = Mock(
-        side_effect=lambda cb: cb()
-    )
-
-    monkeypatch.setattr('idsse.common.rabbitmq_utils.Consumer', mock_obj)
-    return mock_obj
-
-
-@fixture
-def mock_uuid(monkeypatch: MonkeyPatch) -> Mock:
-    """Always return our example UUID str when UUID() is called"""
-    mock_obj = Mock()
-    mock_obj.UUID = Mock(side_effect=lambda: UUID(EXAMPLE_UUID))
-    mock_obj.uuid4 = Mock(side_effect=lambda: EXAMPLE_UUID)
-    monkeypatch.setattr('idsse.common.rabbitmq_utils.uuid', mock_obj)
-    return mock_obj
-
-
-@fixture
-def rpc_thread(mock_consumer: Mock, mock_uuid: Mock) -> RpcPublisher:
-    return RpcPublisher(CONN, RMQ_PARAMS.exchange, timeout=5)
 
 
 # tests
@@ -251,176 +217,6 @@ def test_simple_publisher(monkeypatch: MonkeyPatch, mock_connection: Mock):
 
     publisher.stop()
     assert 'MockChannel.close' in str(mock_threadsafe.call_args[0][1])
-
-
-def test_rpc_opens_new_connection_and_channel(rpc_thread: RpcPublisher, mock_consumer: Mock):
-    assert not rpc_thread.is_open
-    rpc_thread.start()
-
-    mock_consumer.return_value.start.assert_called_once()
-    mock_consumer.return_value.is_alive = Mock(return_value=True)  # Consumer thread would be live
-
-    # stop Rpc client and confirm that Consumer thread was closed
-    rpc_thread.stop()
-    mock_consumer.return_value.is_alive = Mock(return_value=False)  # Consumer thread would be dead
-
-    assert not rpc_thread.is_open
-
-    mock_consumer.return_value.stop.assert_called_once()
-    mock_consumer.return_value.join.assert_called_once()
-
-
-def test_stop_does_nothing_if_not_started(rpc_thread: RpcPublisher, mock_consumer: Mock):
-    # calling stop before starting does nothing
-    rpc_thread.stop()
-    mock_consumer.stop.assert_not_called()
-
-    rpc_thread.start()
-    mock_consumer.return_value.is_alive = Mock(return_value=True)  # Consumer thread would be live
-
-    # calling start when already running does nothing
-    mock_consumer.reset_mock()
-    rpc_thread.start()
-    mock_consumer.return_value.start.assert_not_called()
-
-
-def test_send_request_works_without_calling_start(rpc_thread: RpcPublisher,
-                                                  mock_channel: Mock,
-                                                  mock_connection: Mock,
-                                                  mock_consumer: Mock,
-                                                  monkeypatch: MonkeyPatch):
-    example_message = {'value': 'hello world'}
-
-    # when client calls _blocking_publish, manually invoke response callback with a faked message
-    # from external service, simulating RMQ call/response
-    # pylint: disable=too-many-arguments
-    def mock_blocking_publish(*_args, **_kwargs):
-        # build mock message from imaginary external service
-        method = Method('', 123)
-        props = BasicProperties(content_type='application/json', headers={'rpc': EXAMPLE_UUID})
-        body = bytes(json.dumps(example_message), encoding='utf-8')
-        rpc_thread._on_response(mock_channel, method, props, body)
-
-    monkeypatch.setattr('idsse.common.rabbitmq_utils._blocking_publish',
-                        Mock(side_effect=mock_blocking_publish))
-
-    result = rpc_thread.send_request(RabbitMqMessage(json.dumps({'fake': 'request message'})))
-    assert json.loads(result.body) == example_message
-
-
-def test_send_request_times_out_if_no_response(mock_connection: Mock,
-                                               mock_consumer: Mock,
-                                               mock_uuid: Mock,
-                                               monkeypatch: MonkeyPatch):
-    # create client with same parameters, except a very short timeout
-    _thread = RpcPublisher(CONN, RMQ_PARAMS.exchange, timeout=0.01)
-
-    # do nothing on message publish
-    monkeypatch.setattr('idsse.common.rabbitmq_utils._blocking_publish',
-                        Mock(side_effect=lambda *_args, **_kwargs: None))
-
-    result = _thread.send_request(RabbitMqMessage(json.dumps({'data': 123})))
-    assert EXAMPLE_UUID not in _thread._pending_requests  # request was cleaned up
-    assert result is None
-
-
-def test_send_requests_returns_none_on_error(rpc_thread: RpcPublisher, mock_channel: Mock):
-    # pylint: disable=too-many-arguments
-    def mock_basic_publish(exchange, routing_key, body, properties = None, mandatory = False):
-        # cause exception for pending request Future
-        rpc_thread._pending_requests[EXAMPLE_UUID].set_exception(RuntimeError('Something broke'))
-    mock_channel.basic_publish.side_effect = mock_basic_publish
-
-    result = rpc_thread.send_request(RabbitMqMessage({'data': 123}))
-
-    assert EXAMPLE_UUID not in rpc_thread._pending_requests  # request was cleaned up
-    assert result is None
-
-
-def test_nacks_unrecognized_response(rpc_thread: RpcPublisher,
-                                     mock_connection: Mock,
-                                     mock_channel: Mock,
-                                     monkeypatch: MonkeyPatch):
-    rpc_thread._pending_requests = {'abcd': Future()}
-    delivery_tag = 123
-    props = BasicProperties(content_type='application/json', headers={'rpc': 'unknown_id'})
-    body = bytes(json.dumps({'data': 123}), encoding='utf-8')
-
-    rpc_thread._on_response(mock_channel, Method(delivery_tag=delivery_tag), props, body)
-
-    # unregistered message was nacked
-    mock_channel.basic_nack.assert_called_with(delivery_tag=delivery_tag, requeue=False)
-    # pending requests inside Rpc was not touched
-    assert 'abcd' in rpc_thread._pending_requests
-    assert not rpc_thread._pending_requests['abcd'].done()
-
-
-def test_send_request_preserves_props(rpc_thread: RpcPublisher, mock_channel: Mock):
-    # pylint: disable=too-many-arguments
-    def mock_basic_publish(exchange, routing_key, body, properties = None, mandatory = False):
-        # cause exception for pending request Future
-        rpc_thread._pending_requests[EXAMPLE_UUID].set_exception(RuntimeError('Something broke'))
-    mock_channel.basic_publish.side_effect = mock_basic_publish
-
-    result = rpc_thread.send_request(RabbitMqMessage({'data': 123}))
-
-    assert EXAMPLE_UUID not in rpc_thread._pending_requests  # request was cleaned up
-    assert result is None
-
-
-def test_rpc_consumer_start_stop(mock_consumer: Mock):
-    mock_consumer.return_value.is_alive.return_value = False
-    rpc_consumer = RpcConsumer(CONN, RMQ_PARAMS, lambda: None)
-
-    rpc_consumer.start()
-    mock_consumer.return_value.start.assert_called_once()
-
-    mock_consumer.return_value.is_alive.return_value = True
-
-    rpc_consumer.stop()
-    mock_consumer.return_value.stop.assert_called_once()
-
-
-def test_rpc_consumer_on_message_ack(mock_channel: Mock, mock_consumer: Mock):
-    example_response = RabbitMqMessage('{"response": "bar"}',
-                                       BasicProperties(content_type='application/json',
-                                                       correlation_id='some-correlation-id'))
-    mock_on_request = Mock(return_value=RpcResponse(example_response, ack=True))
-    inbound_tag = 7
-    inbound_rpc_id = '123'
-    inbound_reply_to = f'{DIRECT_REPLY_QUEUE}.g1h2AA5yZXBseUA1NTQ3NDU0OQAWaZUAAAAAZ7FK9g=='
-    inbound_props = BasicProperties(content_type='text/html',
-                                    headers={'rpc': inbound_rpc_id},
-                                    reply_to=inbound_reply_to)
-    inbound_body = bytes('{"request": "foo"}', encoding='utf-8')
-    rpc_consumer = RpcConsumer(CONN, RMQ_PARAMS, mock_on_request)
-
-    rpc_consumer._on_message(mock_channel, Method('', '', inbound_tag), inbound_props, inbound_body)
-
-    mock_channel.basic_ack.assert_called_once_with(inbound_tag)
-    assert mock_channel.basic_publish.call_count == 1
-    published_args = mock_channel.basic_publish.call_args[1]
-    assert published_args['body'] == example_response.body
-    assert published_args['properties'].reply_to == inbound_reply_to
-    assert published_args['properties'].content_type == 'application/json'
-    assert published_args['properties'].correlation_id == 'some-correlation-id'
-    assert published_args['properties'].headers['rpc'] == inbound_rpc_id
-
-
-def test_rpc_consumer_on_message_nack(mock_channel: Mock, mock_consumer: Mock):
-    example_response = RabbitMqMessage('{"response": "bar"}',
-                                       BasicProperties(content_type='application/json'))
-    mock_on_request = Mock(return_value=RpcResponse(example_response, ack=False, requeue=True))
-    inbound_tag = 7
-    inbound_props = BasicProperties(content_type='application/json',
-                                    headers={'rpc': '123'},
-                                    reply_to=DIRECT_REPLY_QUEUE)
-    inbound_body = bytes('{"request": "foo"}', encoding='utf-8')
-    rpc_consumer = RpcConsumer(CONN, RMQ_PARAMS, mock_on_request)
-
-    rpc_consumer._on_message(mock_channel, Method('', '', inbound_tag), inbound_props, inbound_body)
-
-    mock_channel.basic_nack.assert_called_once_with(inbound_tag, requeue=True)
 
 
 @fixture

--- a/python/idsse_common/test/test_rabbitmq_utils.py
+++ b/python/idsse_common/test/test_rabbitmq_utils.py
@@ -23,6 +23,7 @@ from pika import BasicProperties, BlockingConnection
 from pika.adapters.blocking_connection import BlockingChannel
 from pika.exceptions import UnroutableError
 
+
 from idsse.common.rabbitmq_utils import (
     Conn, Consumer, Exch, Future, Queue, Publisher, RabbitMqParams, RabbitMqParamsAndCallback,
     RabbitMqMessage, Rpc, subscribe_to_queue, _publish, _setup_exch_and_queue,


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-1142](https://linear.app/idss/issue/IDSSE-1142)

### Changes
<!-- Brief description of changes -->
- Create `RpcPublisher`
  - `Rpc` class with more specific name. We will delete `Rpc` after all usages in IDSSe services have been migrated
  - Fix minor bug where `Rpc.send_request()` defined its own, hard-coded message properties (`application/json`, for example). Now caller can pass the request message's BasicProperties
- Create `RpcConsumer` class
  - Opposite of `RpcPublisher`, listens for Rpc requests, triggers some `on_message()` function you give it to form a response, then structures the response correctly for Rpc reply

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
Previously we had custom code in DAS that structured and published all its RPC responses in the way that `Rpc` expects. We'd rather have logic for both ends of the RPC in the same place, and we could theoretically use RPC in another service.