### PR TITLE
bug: get_issues() returning same stale issueDt

### DIFF
--- a/python/idsse_common/idsse/common/protocol_utils.py
+++ b/python/idsse_common/idsse/common/protocol_utils.py
@@ -2,11 +2,11 @@
 # -------------------------------------------------------------------------------
 # Created on Tue Dec 3 2024
 #
-# Copyright (c) 2023 Colorado State University. All rights reserved.             (1)
-# Copyright (c) 2023 Regents of the University of Colorado. All rights reserved. (2)
+# Copyright (c) 2024 Colorado State University. All rights reserved.             (1)
 #
 # Contributors:
 #     Paul Hamer (1)
+#     Mackenzie Grimes (1)
 #
 # -------------------------------------------------------------------------------
 import fnmatch
@@ -211,7 +211,9 @@ class ProtocolUtils(ABC):
         """
         issues_set: set[datetime] = set()
         # sort files alphabetically in reverse; this should give us the longest lead time first
-        filepaths = sorted((f for f in self.ls(dir_path) if f.endswith(self.path_builder.file_ext)),
+        # which is more indicative that the issueDt is fully available on this server
+        filepaths = sorted((f for f in self.ls(dir_path)
+                            if f.endswith(self.path_builder.file_ext)),
                            reverse=True)
         for file_path in filepaths:
             try:


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-1215](https://linear.app/idss/issue/IDSSE-1215)

### Changes
<!-- Brief description of changes -->
- ProtocolUtils.get_issues: set `issue_end` to dynamic `now()`, not a default arg in function signature

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
The most common usage of this function in DAS was 
```python
get_issues(num_issues=1, region='CONUS')
```
which left the `issue_end` arg as the default value. 

Because I put `datetime.now(UTC)` in the function signature (not in the body of the function), python was running `.now()` just once on startup (when protocol_utils.py was imported) rather than calling `.now()` every time the function was called as we intended. 

Therefore a DAS instance who received a `"sourceType": "issues"` request would always return the latest issueDt available when it started up--filtering out any newer issues that appeared on the AWS/HTTP server because they were later than the assumed `issue_end` arg.