### PR TITLE
bug: add FileBasedLock (NFS proof)

### DIFF
--- a/python/idsse_common/idsse/common/utils.py
+++ b/python/idsse_common/idsse/common/utils.py
@@ -155,6 +155,9 @@ class FileBasedLock():
         except AttributeError:
             # Linux (and maybe Windows) don't support birthtime
             creation_time = os.stat(self._lock_path).st_ctime
+        except FileNotFoundError:
+            # lock file disappeared since start of function call?? *shrug* treat it as unexpired
+            creation_time = datetime.now(UTC).timestamp()
         return (datetime.now(UTC).timestamp() - creation_time) >= self._max_age
 
     def acquire(self, timeout=300.0) -> bool:
@@ -195,7 +198,7 @@ class FileBasedLock():
 
     def _create_lockfile(self):
         """The actual functionality triggered by `acquire()` (after lock is confirmed free)"""
-        with open(self._lock_path, 'a', encoding='utf-8') as file:
+        with open(self._lock_path, 'w', encoding='utf-8') as file:
             file.write('')
 
 

--- a/python/idsse_common/idsse/common/utils.py
+++ b/python/idsse_common/idsse/common/utils.py
@@ -137,7 +137,8 @@ class FileBasedLock():
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        return self.release()
+        self.release()
+        return False
 
     @property
     def locked(self) -> bool:


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-1164](https://linear.app/idss/issue/IDSSE-1164)

### Changes
<!-- Brief description of changes -->
- Add `utils.FileBasedLock` 

Example:
```py
with FileBasedLock('my_file.grib2', max_age=30):
    # now we're sure our thread alone is reading/writing my_file.grib2
    open('my_file.grib2', 'r') # ...
print('File released to other threads!')
```

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
These changes will make a blank `foo.<ext>.lock` file on the filesystem before reading from/writing to a `foo.<ext>` file. 
- If we find a .lock file already there, we loop waiting for it to disappear.
- If we've waited `max_age` seconds, we assume the thread that locked it is dead somehow, and we take over the file lock anyway.

#### Doesn't every OS have locks built into their file I/O?
Yes, but IDSSe can't always rely on that. Our services can be running on different Kubernetes nodes, or different containers in that node, or different Python/Gunicorn processes, and the filesystem they're reading/writing files from could be local FS, or a Network File Share (NFS). This makes it hard to know _for sure_ that no one else is tinkering with your file when your thread goes to do file I/O.