### PR TITLE
bug: FileBasedLock parent dir may not exist

### DIFF
--- a/python/idsse_common/idsse/common/utils.py
+++ b/python/idsse_common/idsse/common/utils.py
@@ -199,6 +199,7 @@ class FileBasedLock():
 
     def _create_lockfile(self):
         """The actual functionality triggered by `acquire()` (after lock is confirmed free)"""
+        os.makedirs(os.path.dirname(self._lock_path), exist_ok=True)
         with open(self._lock_path, 'w', encoding='utf-8') as file:
             file.write('')
 

--- a/python/idsse_common/idsse/common/utils.py
+++ b/python/idsse_common/idsse/common/utils.py
@@ -128,7 +128,7 @@ class FileBasedLock():
                 based on how long a single thread could reasonably being expected to read/write
                 for this file type and usage.
         """
-        self.filepath = filepath
+        self.filepath = os.path.abspath(filepath)
         self._lock_path = f'{self.filepath}.lock'
         self._max_age = max_age
 


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
N/A (hotfix)

### Changes
<!-- Brief description of changes -->
- Ensure that all parent directories of the target FileBasedLock exist before trying to create a `.lock` file

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
The previous PR (#104), once used by DAS, was throwing uncaught exceptions:
```
FileNotFoundError: [Errno 2] No such file or directory: '/local_data/tmp/NBM/CONUS/2025/04/30/NBM_CONUS_20250430210000_20250501130000.grib2.idx.lock'
```

We failed to consider when FileBasedLock would be used to write data to a directory that didn't yet exist.

Now FileBasedLock will create (but not clean up) any parent directories above the provided filepath, before creating the `.lock`.