### PR TITLE
chore: add black code styling

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# migrate code styling to Black
+a1fc6f561dec7ce5a62d0de79a510e0654cc5c02

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -27,7 +27,7 @@ jobs:
           pip install pytest pytest_httpserver pylint==2.17.5 requests==2.31.0 python-dateutil==2.8.2 pint==0.21 importlib-metadata==6.7.0 jsonschema==4.19.0 pika==1.3.1 pyproj numpy==1.26.2 shapely==2.0.2 netcdf4==1.6.3 h5netcdf==1.1.0 pillow==10.2.0 python-logging-rabbitmq==2.3.0
 
       - name: Checkout idss-engine-commons
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: NOAA-GSL/idss-engine-commons
           path: commons/
@@ -35,9 +35,9 @@ jobs:
       - name: Install IDSSE python commons
         working-directory: commons/python/idsse_common
         run: pip install .
-        
+
       - name: Checkout idsse-testing
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: NOAA-GSL/idsse-testing
           ref: main
@@ -52,4 +52,10 @@ jobs:
           echo "PYTHONPATH=python/idsse_common/idsse/common" >> $GITHUB_ENV
 
       - name: Run code linter
-        run: pylint ./python/idsse_common --max-line-length=120 --recursive true
+        run: pylint ./python/idsse_common --max-line-length=100 --recursive true
+
+      - name: Run black formatter
+        uses: psf/black@stable
+        with:
+          options: "--check --line-length 99"  # effectively 100, but black formatter has a bug
+          src: "./python"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 25.1.0
+    hooks:
+      - id: black
+        # It is recommended to specify the latest version of Python
+        # supported by your project here, or alternatively use
+        # pre-commit's default_language_version, see
+        # https://pre-commit.com/#top_level-default_language_version
+        language_version: python3.11
+        # really line length 100 but black has a bug with lines that are exactly the length limit
+        args: ["--line-length", "99"]

--- a/README.md
+++ b/README.md
@@ -9,12 +9,52 @@
 The `idss-engine-commons` project is responsible for defining all implicit common dependencies that are used by the apps that make up the IDSS Engine Project distributed system. This
 repository should be used to house elements that are common across multiple projects to encourage reuse.
 
-
-# Twelve-Factors
+## Twelve-Factors
 The complete twelve-factors methodologies that the IDSS Engine Project adheres to can be found in the umbrella [idss-engine](https://github.com/NOAA-GSL/idss-engine) repository. The subset of the twelve factors that follows are specifics to this app only.
 
 ## Logging
 To support some standardization and best practices for IDSS Engine, developers should following the logging guide found [here](python/logging.rst)
+
+## Contributing
+Clone this repository.
+
+Create a Python pip environment and activate it:
+```sh
+python3 -m venv .venv && source .venv/bin/activate
+```
+
+Install all Python dependencies based on what is installed in any of the GitHub Actions in `.github/workflows`, e.g. `linter.yml`.
+```sh
+pip install <libs_from_.github/workflows/linter.yml>
+```
+
+If you intend to run unit tests, you'll need to clone the [idsse-testing](https://github.com/NOAA-GSL/idsse-testing) GitHub repository, then install it as an "editable" (a.k.a. local) pip package:
+```sh
+pip install -e <path_to_idsse_testing_clone>/python
+```
+
+### Formatting
+Python code is formatted according to the [black](https://black.readthedocs.io/) style guide, and any Pull Requests will be checked against this styling to ensure the new code has been auto-formatted.
+
+To have `black` reformat all Python code every time you create a git commit, install the [pre-commit](https://pre-commit.com/) library:
+```sh
+pip install pre-commit
+```
+
+And run this to have any Git pre-commit hooks installed for you according to `.pre-commit.config.yaml`:
+```sh
+pre-commit install
+```
+
+If you prefer, you can install the `black` library and run it yourself manually (not running on `git commit`):
+```sh
+pip install black
+```
+
+This will reformat all your Python files for you:
+```sh
+black . --line-length 99
+```
 
 ## Build, Release, and Run
 The subsections below outline how to build the common images within this project. All microservices built with Docker are done within the
@@ -69,7 +109,7 @@ can create their own RabbitMQ service as follows:
 
 #### Build
 From the IDSS Engine project root directory `idss-engine/build/<env>/<arch>/`:
-  
+
 `$ docker-compose build couch_db`
 
 **Development Image Name** `idss.engine.commons.couchbase.server:<tag>`

--- a/couchdb/test/src/test.py
+++ b/couchdb/test/src/test.py
@@ -1,9 +1,10 @@
-'''/*******************************************************************************
- * Copyright (c) 2022 Regents of the University of Colorado. All rights reserved.
- *
- * Contributors:
- *     Michael Rabellino
- *******************************************************************************/'''
+"""/*******************************************************************************
+* Copyright (c) 2022 Regents of the University of Colorado. All rights reserved.
+*
+* Contributors:
+*     Michael Rabellino
+*******************************************************************************/"""
+
 import pycouchdb
 import sys
 import logging
@@ -13,52 +14,59 @@ import argparse as ap
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
-    handlers=[
-        logging.StreamHandler(sys.stdout)
-    ]
+    handlers=[logging.StreamHandler(sys.stdout)],
 )
+
 
 def main():
     usage = "usage: %prog --host host --username couchdb_username --password couchdb_password"
     parser = ap.ArgumentParser()
-    parser.add_argument('--host', dest='host', help='The host name used for the couchdb server')
-    parser.add_argument('--username', dest='username', help='The username used to connect to the couchdb server')
-    parser.add_argument('--password', dest='password', help='The password used to connect to the couchdb server')
+    parser.add_argument("--host", dest="host", help="The host name used for the couchdb server")
+    parser.add_argument(
+        "--username", dest="username", help="The username used to connect to the couchdb server"
+    )
+    parser.add_argument(
+        "--password", dest="password", help="The password used to connect to the couchdb server"
+    )
     args = parser.parse_args()
 
     if args.host == None:
-        raise RuntimeError('Unknown couchdb host, check configuration')
+        raise RuntimeError("Unknown couchdb host, check configuration")
     host = args.host
 
     if args.username == None:
-        raise RuntimeError('Unknown couchdb username, check configuration')
+        raise RuntimeError("Unknown couchdb username, check configuration")
     username = args.username
 
     if args.password == None:
-        raise RuntimeError('Unknown couchdb password, check configuration')
+        raise RuntimeError("Unknown couchdb password, check configuration")
     password = args.password
 
     return host, username, password
 
-if __name__ == '__main__':
-    logging.info('Running python test to verify connection to couchdb container')
+
+if __name__ == "__main__":
+    logging.info("Running python test to verify connection to couchdb container")
     try:
         host, username, password = main()
 
-        logging.info('    host: %s', host)
-        logging.info('    username: %s', username)
-        logging.info('    password: %s', password)
+        logging.info("    host: %s", host)
+        logging.info("    username: %s", username)
+        logging.info("    password: %s", password)
 
         # build the url for the couchdb
-        couch_url = 'http://' + username + ':' + password + '@' + host + ':5984'
+        couch_url = "http://" + username + ":" + password + "@" + host + ":5984"
 
         # try to connect
-        logging.info('Attempting to connect to couchdb at: %s', couch_url)
+        logging.info("Attempting to connect to couchdb at: %s", couch_url)
         server = pycouchdb.Server(couch_url)
 
         # print something out from the server to demonstrate connectivity
-        logging.info('    connected to the couch server which is running version: %s', server.info()['version'])
+        logging.info(
+            "    connected to the couch server which is running version: %s",
+            server.info()["version"],
+        )
     except Exception as e:
-        logging.error('Failed to test couchdb driver due to exception: %s', str(e))
+        logging.error("Failed to test couchdb driver due to exception: %s", str(e))
     finally:
-        logging.info('Test Complete!')
+        logging.info("Test Complete!")

--- a/couchdb/test/test_couchdb_driver.py
+++ b/couchdb/test/test_couchdb_driver.py
@@ -1,9 +1,9 @@
-'''/*******************************************************************************
- * Copyright (c) 2022 Regents of the University of Colorado. All rights reserved.
- *
- * Contributors:
- *     Michael Rabellino
- *******************************************************************************/'''
+"""/*******************************************************************************
+* Copyright (c) 2022 Regents of the University of Colorado. All rights reserved.
+*
+* Contributors:
+*     Michael Rabellino
+*******************************************************************************/"""
 
 import os
 import sys
@@ -16,112 +16,131 @@ import urllib, urllib.request
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
-    handlers=[
-        logging.StreamHandler(sys.stdout)
-    ]
+    handlers=[logging.StreamHandler(sys.stdout)],
 )
 
-if '__main__' == __name__:
-    logging.info('-----------------------------------------------------------')
-    logging.info('Running couchdb test with arguments: ' + str(sys.argv))
+if "__main__" == __name__:
+    logging.info("-----------------------------------------------------------")
+    logging.info("Running couchdb test with arguments: " + str(sys.argv))
 
     host = sys.argv[1]
     username = sys.argv[2]
     password = sys.argv[3]
 
     # static test configuration
-    network = 'couch-test-network'
-    server_image = 'idss.engine.commons.couchdb.server:test'
-    test_image = 'idss.engine.commons.couchdb.client:test'
+    network = "couch-test-network"
+    server_image = "idss.engine.commons.couchdb.server:test"
+    test_image = "idss.engine.commons.couchdb.client:test"
 
     # create a network for the couchdb server and test to run on
     try:
-        subprocess.check_output('docker network create ' + network, shell=True).decode('utf-8')
-        logging.info('Created docker network: %s', network)
+        subprocess.check_output("docker network create " + network, shell=True).decode("utf-8")
+        logging.info("Created docker network: %s", network)
     except Exception as e:
-        logging.warning('Container network already detected, continuing')
+        logging.warning("Container network already detected, continuing")
 
     # build the couchdb server container
     try:
-        logging.info('Building couchdb server image')
-        subprocess.check_output('cd ..; docker build -t ' + server_image + ' .', shell=True).decode('utf-8')
+        logging.info("Building couchdb server image")
+        subprocess.check_output(
+            "cd ..; docker build -t " + server_image + " .", shell=True
+        ).decode("utf-8")
     except Exception as e:
-        logging.warning('Unable to build server container due to exception: %s', str(e))
+        logging.warning("Unable to build server container due to exception: %s", str(e))
 
     # build the test container
     try:
-        logging.info('Building test image')
-        subprocess.check_output('docker build -t ' + test_image + ' .', shell=True).decode('utf-8')
+        logging.info("Building test image")
+        subprocess.check_output("docker build -t " + test_image + " .", shell=True).decode("utf-8")
     except Exception as e:
-        logging.warning('Unable to build test container due to exception: %s', str(e))
-    
+        logging.warning("Unable to build test container due to exception: %s", str(e))
+
     # run the couchdb server container
     try:
-        logging.info('Running the couchdb server container')
+        logging.info("Running the couchdb server container")
         couchdb_docker_server_cmd = (
-            'docker run --rm -d --name ' + host + ' ' +
-            '--network ' + network + ' ' +
-            '-e COUCHDB_USER=' + username + ' ' +
-            '-e COUCHDB_PASSWORD=' + password + ' ' +
-            '-p 5984:5984 ' +
-            server_image
+            "docker run --rm -d --name "
+            + host
+            + " --network "
+            + network
+            + " -e COUCHDB_USER="
+            + username
+            + " -e COUCHDB_PASSWORD="
+            + password
+            + " -p 5984:5984 "
+            + server_image
         )
         logging.info(couchdb_docker_server_cmd)
-        subprocess.check_output(couchdb_docker_server_cmd, shell=True).decode('utf-8')
+        subprocess.check_output(couchdb_docker_server_cmd, shell=True).decode("utf-8")
     except Exception as e:
-        logging.warning('Unable to start the couchdb server container due to exception: %s', str(e))
+        logging.warning(
+            "Unable to start the couchdb server container due to exception: %s", str(e)
+        )
 
     # allow for some time for the couchdb server to start
-    logging.info('Waiting for couchdb server to start...')
+    logging.info("Waiting for couchdb server to start...")
     time.sleep(10)
 
     # run the test container
     try:
-        logging.info('Running the test container')
+        logging.info("Running the test container")
         couchdb_docker_test_cmd = (
-            'docker run --network ' + network + ' ' +
-            test_image + ' ' +
-            '--host=' + host + ' ' +
-            '--username=' + username + ' ' +
-            '--password=' + password + ' '
+            "docker run --network "
+            + network
+            + " "
+            + test_image
+            + " --host="
+            + host
+            + " --username="
+            + username
+            + " --password="
+            + password
         )
         logging.info(couchdb_docker_test_cmd)
         os.system(couchdb_docker_test_cmd)
     except Exception as e:
-        logging.warning('Unable to run the test container due to exception: %s', str(e))
+        logging.warning("Unable to run the test container due to exception: %s", str(e))
 
     # cleanup
-    logging.info('-----------')
-    logging.info('Cleaning up')
+    logging.info("-----------")
+    logging.info("Cleaning up")
 
     # stop test server container
     try:
-        subprocess.check_output('docker stop ' + host, shell=True).decode('utf-8')
-        logging.info('Removed test couchdb container: %s', host)
+        subprocess.check_output("docker stop " + host, shell=True).decode("utf-8")
+        logging.info("Removed test couchdb container: %s", host)
     except Exception as e:
-        logging.warning('Unable to stop server container, please stop manually: $ docker stop %s', host)
+        logging.warning(
+            "Unable to stop server container, please stop manually: $ docker stop %s", host
+        )
     # remove test server image
     try:
-        subprocess.check_output('docker image rm -f ' + server_image, shell=True).decode('utf-8')
-        logging.info('Removed docker image: %s', server_image)
+        subprocess.check_output("docker image rm -f " + server_image, shell=True).decode("utf-8")
+        logging.info("Removed docker image: %s", server_image)
     except Exception as e:
-        logging.warning('Unable to remove server image, please delete manually: $ docker image rm %s', server_image)
+        logging.warning(
+            "Unable to remove server image, please delete manually: $ docker image rm %s",
+            server_image,
+        )
 
     # remove test container
     try:
-        subprocess.check_output('docker image rm -f ' + test_image, shell=True).decode('utf-8')
-        logging.info('Removed docker image: %s', test_image)
+        subprocess.check_output("docker image rm -f " + test_image, shell=True).decode("utf-8")
+        logging.info("Removed docker image: %s", test_image)
     except Exception as e:
-        logging.warning('Unable to remove test image, please delete manually: $ docker image rm %s', test_image)
+        logging.warning(
+            "Unable to remove test image, please delete manually: $ docker image rm %s", test_image
+        )
 
     # remove docker network
     try:
-        subprocess.check_output('docker network rm ' + network, shell=True).decode('utf-8')
-        logging.info('Removed docker network: %s', network)
+        subprocess.check_output("docker network rm " + network, shell=True).decode("utf-8")
+        logging.info("Removed docker network: %s", network)
     except Exception as e:
-        logging.warning('Unable to remove container network, please delete manually: $ docker network rm %s', network)
-    
+        logging.warning(
+            "Unable to remove container network, please delete manually: $ docker network rm %s",
+            network,
+        )
 
-    logging.info('Done')
-    logging.info('-----------------------------------------------------------')
-
+    logging.info("Done")
+    logging.info("-----------------------------------------------------------")

--- a/couchdb/uat/loader/CouchEventPortfolioDB.py
+++ b/couchdb/uat/loader/CouchEventPortfolioDB.py
@@ -9,12 +9,11 @@ import pycouchdb
 
 # configure logging
 import logging
+
 logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(message)s",
     level=logging.INFO,
-    handlers=[
-        logging.StreamHandler(sys.stdout)
-    ]
+    handlers=[logging.StreamHandler(sys.stdout)],
 )
 
 
@@ -23,10 +22,10 @@ class CouchEventPortfolioDB(object):
     def __init__(self, config: Dict):
         self.db = None
         self.dbServer = None
-        self.hostname = config['hostname']
-        self.username = config['username']
-        self.password = config['password']
-        self.database = config['database']
+        self.hostname = config["hostname"]
+        self.username = config["username"]
+        self.password = config["password"]
+        self.database = config["database"]
 
         # Set up the database access
         self._connect()
@@ -36,99 +35,115 @@ class CouchEventPortfolioDB(object):
 
     def _connect(self):
         try:
-            self.couch_url = 'http://' + self.username + ':' + self.password + '@' + self.hostname + ':5984'
-            logging.info('Attempting to connect to couchdb at: %s', self.couch_url)
+            self.couch_url = (
+                "http://" + self.username + ":" + self.password + "@" + self.hostname + ":5984"
+            )
+            logging.info("Attempting to connect to couchdb at: %s", self.couch_url)
             self.dbServer = pycouchdb.Server(self.couch_url)
-            logging.info('SERVER : %s : %s', str(self.dbServer), str(self.dbServer.info()))
+            logging.info("SERVER : %s : %s", str(self.dbServer), str(self.dbServer.info()))
 
         except Exception as e:
             logging.error("Cannot connect to server {} : {}".format(self.hostname, e))
-            raise cherrypy.HTTPError(500, message='Unable to connect to server, see logs for details.')
+            raise cherrypy.HTTPError(
+                500, message="Unable to connect to server, see logs for details."
+            )
         return
 
     def _open(self):
         try:
-            logging.info('Attempting to open an existing database: %s', self.database)
+            logging.info("Attempting to open an existing database: %s", self.database)
             self.db = self.dbServer.database(self.database)
         except pycouchdb.exceptions.NotFound:
-            logging.info('Database not found, attempting to create: %s', self.database)
+            logging.info("Database not found, attempting to create: %s", self.database)
             self.db = self.dbServer.create(self.database)
         except Exception as e:
             logging.error("Cannot access database {} : {}".format(self.database, e))
-            raise cherrypy.HTTPError(500, message='Unable to open the database, see logs for details.')
+            raise cherrypy.HTTPError(
+                500, message="Unable to open the database, see logs for details."
+            )
         return
 
     def save_portfolio(
-            self,
-            event: Dict = None,
+        self,
+        event: Dict = None,
     ) -> str:
         if event is None:
-            raise cherrypy.HTTPError(500, message='Cannot save an empty event portfolio?')
+            raise cherrypy.HTTPError(500, message="Cannot save an empty event portfolio?")
 
         # ID is created using the Identifier from the event JSON, get the info required...
-        ident = event['corrId']
-        originator = ident['originator']
-        key = ident['uuid']
+        ident = event["corrId"]
+        originator = ident["originator"]
+        key = ident["uuid"]
         # We can update this after 3.7+ to use datatime.fromisoformat(ident['issueDt'])
         # issueDt = datetime.strptime(ident['issueDt'], "%Y-%m-%dT%H:%M:%S.%fZ")
-        issueDt = self._get_isoTime(ident['issueDt'])
-        identifier = '_'.join(['EventPort', originator, key, issueDt.strftime('%Y%m%d-%H%M%S')])
+        issueDt = self._get_isoTime(ident["issueDt"])
+        identifier = "_".join(["EventPort", originator, key, issueDt.strftime("%Y%m%d-%H%M%S")])
         try:
-            doc = {'_id': identifier, 'event': event}
+            doc = {"_id": identifier, "event": event}
             self.db.save(doc)
-            logging.info('Saved %s', identifier)
+            logging.info("Saved %s", identifier)
         except Exception as e:
-            logging.warning('Database error : %s', str(e))
-            raise cherrypy.HTTPError(500, message='Unable to persist event portfolio, see logs for details.')
+            logging.warning("Database error : %s", str(e))
+            raise cherrypy.HTTPError(
+                500, message="Unable to persist event portfolio, see logs for details."
+            )
         return ident
 
-    def get_portfolio(
-            self,
-            uuids: str,
-            issue: datetime = None
-    ) -> Dict:
+    def get_portfolio(self, uuids: str, issue: datetime = None) -> Dict:
         # Handle some of the defaults...
         if issue is None:
-            logging.info('get_portfolio issue wasnt set, using default datetime.utcnow() of :%s ', datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S'))
+            logging.info(
+                "get_portfolio issue wasnt set, using default datetime.utcnow() of :%s ",
+                datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S"),
+            )
             issue = datetime.utcnow()
         else:
-            logging.info('get_portfolio issue set by user, using: %s', issue.strftime('%Y-%m-%dT%H:%M:%S'))
+            logging.info(
+                "get_portfolio issue set by user, using: %s", issue.strftime("%Y-%m-%dT%H:%M:%S")
+            )
 
         if uuids is None or not self.is_valid_uuid(uuids):
-            logging.error('You must provide a valid UUID to get a Portfolio? (%s)', uuids)
-            raise cherrypy.HTTPError(500, message='Invalid UUID, see logs for details.')
+            logging.error("You must provide a valid UUID to get a Portfolio? (%s)", uuids)
+            raise cherrypy.HTTPError(500, message="Invalid UUID, see logs for details.")
 
-        logging.info('Looking for %s with issue %s', uuids, issue.strftime('%Y-%m-%dT%H:%M:%S'))
+        logging.info("Looking for %s with issue %s", uuids, issue.strftime("%Y-%m-%dT%H:%M:%S"))
 
         # Collect all the portfolios with the UUID and select the appropriate one from the issue time.
         portfolio = None
         portfolio_id = None
         try:
             for ident in list(self.db.query("event/idents", startkey=uuids, endkey=uuids)):
-                logging.info('Found %s with issue time of %s',
-                             ident['id'], self._get_isoTime(ident['value']['issueDt']))
-                if self._get_isoTime(ident['value']['issueDt']) <= issue:
-                    portfolio_id = ident['id']
+                logging.info(
+                    "Found %s with issue time of %s",
+                    ident["id"],
+                    self._get_isoTime(ident["value"]["issueDt"]),
+                )
+                if self._get_isoTime(ident["value"]["issueDt"]) <= issue:
+                    portfolio_id = ident["id"]
             if portfolio_id:
                 # Retrieve this event portfolio document and return
-                logging.info('Fetching event portfolio with uuid: %s', str(portfolio_id))
-                portfolio = self.db.get(portfolio_id)['event']
+                logging.info("Fetching event portfolio with uuid: %s", str(portfolio_id))
+                portfolio = self.db.get(portfolio_id)["event"]
         except Exception as e:
-            logging.warning('Database error : %s', str(e))
-            raise cherrypy.HTTPError(500, message='Unable to locate event portfolio, see logs for details.')
+            logging.warning("Database error : %s", str(e))
+            raise cherrypy.HTTPError(
+                500, message="Unable to locate event portfolio, see logs for details."
+            )
 
         if not portfolio:
-            logging.warning('Unable to locate and/or read requested event portfolio: %s', uuids)
-            raise cherrypy.HTTPError(404, message='Unable to locate event portfolio, see logs for details.')
+            logging.warning("Unable to locate and/or read requested event portfolio: %s", uuids)
+            raise cherrypy.HTTPError(
+                404, message="Unable to locate event portfolio, see logs for details."
+            )
 
-        logging.info('Returning portfolio json: %s', portfolio)
+        logging.info("Returning portfolio json: %s", portfolio)
         return portfolio
 
     def get_portfolio_valid(
-            self,
-            issue: datetime = None,
-            start: datetime = None,  # Valid start time
-            end: datetime = None     # Valid end time
+        self,
+        issue: datetime = None,
+        start: datetime = None,  # Valid start time
+        end: datetime = None,  # Valid end time
     ) -> List:
 
         # Handle some of the defaults...
@@ -138,11 +153,13 @@ class CouchEventPortfolioDB(object):
             start = datetime.utcnow()
         if end is None:
             end = start + timedelta(hours=24)
-        uuids = []   # Start with an empty list...
+        uuids = []  # Start with an empty list...
 
         if end < start:
-            logging.error('Get portfolio has valid time end is less than the start time?')
-            raise cherrypy.HTTPError(500, message='Get portfolio has valid time end is less than the start time?')
+            logging.error("Get portfolio has valid time end is less than the start time?")
+            raise cherrypy.HTTPError(
+                500, message="Get portfolio has valid time end is less than the start time?"
+            )
 
         for uuid in self.get_uuids():
             # Collect all the UUIDs for the issue time within the appropriate valid window
@@ -150,24 +167,28 @@ class CouchEventPortfolioDB(object):
             try:
                 idents = list(self.db.query("event/idents", startkey=uuid, endkey=uuid))
                 for ident in idents:
-                    if self._get_isoTime(ident['value']['issueDt']) <= issue:
-                        portfolio_id = ident['id']
+                    if self._get_isoTime(ident["value"]["issueDt"]) <= issue:
+                        portfolio_id = ident["id"]
 
                 if portfolio_id:
                     # Retrieve this event portfolio document and check the valid ranges...
-                    portfolio = self.db.get(portfolio_id)['event']
+                    portfolio = self.db.get(portfolio_id)["event"]
                     # Only interested in those portfolios with 'timing' field...
                     try:
-                        timing = portfolio['timing']
+                        timing = portfolio["timing"]
                         if self._check_valids(timing, start, end):
                             uuids.append(uuid)
                     except Exception as e:
                         # Old format portfolio, no valid time info found. Ignore?
-                        logging.debug('No valid timing found error : %s : %s', str(portfolio_id), str(e))
+                        logging.debug(
+                            "No valid timing found error : %s : %s", str(portfolio_id), str(e)
+                        )
 
             except Exception as e:
-                logging.warning('Database error : %s', str(e))
-                raise cherrypy.HTTPError(500, message='Unable to locate event portfolio, see logs for details.')
+                logging.warning("Database error : %s", str(e))
+                raise cherrypy.HTTPError(
+                    500, message="Unable to locate event portfolio, see logs for details."
+                )
 
         return uuids
 
@@ -177,17 +198,14 @@ class CouchEventPortfolioDB(object):
         # Query the current cluster for the UUID's from the identifier.key value for each document...
         uuids = set()
         try:
-            for ul in list(self.db.query("event/uuids", group='true')):
-                uuids.add(ul['key'])
+            for ul in list(self.db.query("event/uuids", group="true")):
+                uuids.add(ul["key"])
         except Exception as e:
-            logging.warning('Database error when getting UUIDs: %s', str(e))
-            raise cherrypy.HTTPError(500, message='Database error, see logs for details.')
+            logging.warning("Database error when getting UUIDs: %s", str(e))
+            raise cherrypy.HTTPError(500, message="Database error, see logs for details.")
         return list(uuids)
 
-    def purge_portfolios(
-        self,
-        issue: datetime = None
-    ) -> None:
+    def purge_portfolios(self, issue: datetime = None) -> None:
         # Handle some of the defaults...
         if issue is None:
             issue = datetime.utcnow() - timedelta(days=28)
@@ -198,14 +216,14 @@ class CouchEventPortfolioDB(object):
                 # Check the issue to time to see if this portfolio has expired
                 idents = list(self.db.query("event/idents", startkey=uuid, endkey=uuid))
                 for ident in idents:
-                    if self._get_isoTime(ident['value']['issueDt']) <= issue:
+                    if self._get_isoTime(ident["value"]["issueDt"]) <= issue:
                         # Remove this one...
-                        logging.info('Purging : %s', ident['id'])
-                        self.db.delete(ident['id'])
+                        logging.info("Purging : %s", ident["id"])
+                        self.db.delete(ident["id"])
 
         except Exception as e:
-            logging.warning('Database error when getting UUIDs: %s', str(e))
-            raise cherrypy.HTTPError(500, message='Database error, see logs for details.')
+            logging.warning("Database error when getting UUIDs: %s", str(e))
+            raise cherrypy.HTTPError(500, message="Database error, see logs for details.")
         return
 
     def _load_views(self):
@@ -218,17 +236,16 @@ class CouchEventPortfolioDB(object):
                 "idents": {
                     "map": "function(doc) { emit(doc.event.corrId.uuid, doc.event.corrId); }",
                 },
-
                 "uuids": {
                     "map": "function(doc) { emit(doc.event.corrId.uuid, 1); }",
                     "reduce": "function(k,v) {return sum(v); }",
                 },
-            }
+            },
         }
         try:
             self.db.save(_doc)
         except pycouchdb.exceptions.Conflict:
-            logging.info('Conflict in saving views, assume these are already present in database.')
+            logging.info("Conflict in saving views, assume these are already present in database.")
         return
 
     @staticmethod
@@ -239,31 +256,27 @@ class CouchEventPortfolioDB(object):
             return False
         return True
 
-    def _check_valids(self,
-                      timing: Dict,
-                      start: datetime,
-                      end: datetime
-                      ) -> bool:
+    def _check_valids(self, timing: Dict, start: datetime, end: datetime) -> bool:
         try:
-            logging.debug('%s : %s,%s', str(timing), str(start), str(end))
+            logging.debug("%s : %s,%s", str(timing), str(start), str(end))
 
             # Check for validDt list
-            valids = timing['validDts']
+            valids = timing["validDts"]
             for v in valids:
                 if start <= self._get_isoTime(v) <= end:
                     return True
         except Exception as vm:
-            logging.debug('validDts missing : ', str(vm))
+            logging.debug("validDts missing : ", str(vm))
             # Assume we have startDt/endDt?
             try:
-                sDt = timing['startDt']
+                sDt = timing["startDt"]
                 if start <= self._get_isoTime(sDt) <= end:
                     return True
-                eDt = timing['endDt']
+                eDt = timing["endDt"]
                 if start <= self._get_isoTime(eDt) <= end:
                     return True
             except Exception as e:
-                logging.debug('No valid timing information found? : %s', str(e))
+                logging.debug("No valid timing information found? : %s", str(e))
 
         return False
 
@@ -272,6 +285,8 @@ class CouchEventPortfolioDB(object):
         try:
             isoTime = datetime.strptime(dtStr, "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=None)
         except Exception as e:
-            logging.error('Could not convert string %s to isoTime? : %s', dtStr, str(e))
-            raise cherrypy.HTTPError(500, message='Unable to convert string to datetime, see logs for details.')
+            logging.error("Could not convert string %s to isoTime? : %s", dtStr, str(e))
+            raise cherrypy.HTTPError(
+                500, message="Unable to convert string to datetime, see logs for details."
+            )
         return isoTime

--- a/couchdb/uat/loader/Load.py
+++ b/couchdb/uat/loader/Load.py
@@ -4,21 +4,21 @@ import os
 import CouchEventPortfolioDB
 from pathlib import Path
 
-if __name__ == '__main__':
-    logging.info('Starting the event portfolio manager load service for UAT...')
+if __name__ == "__main__":
+    logging.info("Starting the event portfolio manager load service for UAT...")
     try:
-        dbcfg = 'couchdb.json'
-        datadir = '/data/'
+        dbcfg = "couchdb.json"
+        datadir = "/data/"
 
         # Get a database instance here...
-        with open(dbcfg, 'r', encoding='utf-8') as cfg:
+        with open(dbcfg, "r", encoding="utf-8") as cfg:
             data = json.loads(cfg.read())
 
             db = CouchEventPortfolioDB.CouchEventPortfolioDB(data)
 
-            logging.info('Purge the database before loading new event portfolios...')
+            logging.info("Purge the database before loading new event portfolios...")
             db.purge_portfolios()
-            logging.info('Database purged successfully')
+            logging.info("Database purged successfully")
 
             # Get each of the JSON files from the given data directory and load into the database
             for fn in sorted(Path(datadir).glob("*.json"), reverse=True):
@@ -27,11 +27,15 @@ if __name__ == '__main__':
                         with open(fn) as json_file:
                             db.save_portfolio(json.load(json_file))
                     except Exception as e:
-                        logging.warning('Unable to save event portfolio from %s due to exception: %s', str(fn), str(e))
+                        logging.warning(
+                            "Unable to save event portfolio from %s due to exception: %s",
+                            str(fn),
+                            str(e),
+                        )
                 else:
-                    logging.warning('Unable to located and/or read event portfolio: %s', fn)
+                    logging.warning("Unable to located and/or read event portfolio: %s", fn)
 
     except Exception as e:
-        logging.error('Could not start the event portfolio manager loader due to exception: %s', e)
+        logging.error("Could not start the event portfolio manager loader due to exception: %s", e)
     finally:
-        logging.info('Shutting down the event portfolio manager loader')
+        logging.info("Shutting down the event portfolio manager loader")

--- a/docker/python/setup.py
+++ b/docker/python/setup.py
@@ -1,30 +1,27 @@
 """Setup to support installation as Python library"""
+
 import glob
 from setuptools import setup
 
-setup(name='idsse',
-      version='1.0',
-      description='IDSSe Common',
-      url='',
-      author='WIDS',
-      author_email='@noaa.gov',
-      license='MIT',
-      python_requires=">=3.11",
-      packages=['idsse.common', 'idsse.common.schema'],
-      data_files=[('idsse/common/schema', glob.glob('idsse/common/schema/*.json'))],
-      include_package_data=True,
-      package_data={'':['schema/*.json']},
-      install_requires=[
-        'pint',
-        'importlib_metadata',
-        'pika',
-        'jsonschema'
-      ],
-      extras_require={
-        'develop': [
-          'pytest',
-          'pytest-cov',
+setup(
+    name="idsse",
+    version="1.0",
+    description="IDSSe Common",
+    url="",
+    author="WIDS",
+    author_email="@noaa.gov",
+    license="MIT",
+    python_requires=">=3.11",
+    packages=["idsse.common", "idsse.common.schema"],
+    data_files=[("idsse/common/schema", glob.glob("idsse/common/schema/*.json"))],
+    include_package_data=True,
+    package_data={"": ["schema/*.json"]},
+    install_requires=["pint", "importlib_metadata", "pika", "jsonschema"],
+    extras_require={
+        "develop": [
+            "pytest",
+            "pytest-cov",
         ]
-      },
-      zip_safe=False,
+    },
+    zip_safe=False,
 )

--- a/python/Roads/segment.py
+++ b/python/Roads/segment.py
@@ -1,75 +1,67 @@
-
-
-
 from math import radians, degrees, sin, cos, asin, acos, sqrt
 import json
 import copy
 
 segment_distance = 100
 
+
 def great_circle_miles(lon1, lat1, lon2, lat2):
     lon1, lat1, lon2, lat2 = map(radians, [lon1, lat1, lon2, lat2])
-    return 3958.756 * (
-        acos(sin(lat1) * sin(lat2) + cos(lat1) * cos(lat2) * cos(lon1 - lon2))
-    )
+    return 3958.756 * (acos(sin(lat1) * sin(lat2) + cos(lat1) * cos(lat2) * cos(lon1 - lon2)))
+
 
 def subdividefeature(feature):
-    #split one feature into multiple based on segment_distance
+    # split one feature into multiple based on segment_distance
     totaldistance = 0
     newfeatures = []
     points = []
     featuress = []
-    path = feature['geometry']['coordinates']
+    path = feature["geometry"]["coordinates"]
     for i in range(1, len(path)):
-        lon1 = path[i-1][0] 
-        lat1 = path[i-1][1] 
-        lon2 = path[i  ][0]
-        lat2 = path[i  ][1]
+        lon1 = path[i - 1][0]
+        lat1 = path[i - 1][1]
+        lon2 = path[i][0]
+        lat2 = path[i][1]
         totaldistance = totaldistance + great_circle_miles(lon1, lat1, lon2, lat2)
-        points.append([lon1,lat1])
-        #write points to array if we exceed segment_distance or if this is the last time through loop
-        if totaldistance > segment_distance or i == len(path)-1:
+        points.append([lon1, lat1])
+        # write points to array if we exceed segment_distance or if this is the last time through loop
+        if totaldistance > segment_distance or i == len(path) - 1:
             totaldistance = 0
-            #add last point to array
-            points.append([lon2,lat2])
-            #copy current feature
+            # add last point to array
+            points.append([lon2, lat2])
+            # copy current feature
             feat = feature.copy()
-            #overwrite old coordinates
-            feat['geometry']['coordinates'] = points.copy()
-            #clear points for next segment
+            # overwrite old coordinates
+            feat["geometry"]["coordinates"] = points.copy()
+            # clear points for next segment
             points = []
-            #add this feature to all features
+            # add this feature to all features
             featuress.append(copy.deepcopy(feat))
 
     return featuress
 
-        
-def makenewfeature(data,outfile):
+
+def makenewfeature(data, outfile):
     features = []
-    for feature in data['features']:
-        path = feature['geometry']['coordinates']
+    for feature in data["features"]:
+        path = feature["geometry"]["coordinates"]
         newfeatures = subdividefeature(feature)
         features = features + newfeatures
-    #Overwrite old features
-    data['features'] = features
+    # Overwrite old features
+    data["features"] = features
 
-    #write to file
-    with open(outfile, 'w') as outfile:
+    # write to file
+    with open(outfile, "w") as outfile:
         json.dump(data, outfile)
-    
-    
+
 
 files = ["I-15.json", "I-25.json", "I-70.json", "I-80.json", "I-90.json", "I-94.json"]
-#files = ["I-15.json"]
+# files = ["I-15.json"]
 folder = "Compressed"
 
 for file in files:
     path = folder + "/" + file
     outfile = folder + "/" + "segment_" + str(segment_distance) + "_" + file
-    print (outfile)
-    with open(path, 'r') as f:
-        makenewfeature(json.load(f),outfile)
-
-
-
-
+    print(outfile)
+    with open(path, "r") as f:
+        makenewfeature(json.load(f), outfile)

--- a/python/idsse_common/idsse/common/config.py
+++ b/python/idsse_common/idsse/common/config.py
@@ -1,4 +1,5 @@
 """Utility for loading configuration data"""
+
 # ------------------------------------------------------------------------------
 # Created on Wed Mar 01 2023
 #
@@ -21,11 +22,14 @@ logger = logging.getLogger(__name__)
 
 class Config:
     """Configuration data class"""
-    def __init__(self,
-                 config: dict | Iterable[dict] | str,
-                 keys: Iterable | str | None = None,
-                 recursive: bool = False,
-                 ignore_missing: bool = False) -> None:
+
+    def __init__(
+        self,
+        config: dict | Iterable[dict] | str,
+        keys: Iterable | str | None = None,
+        recursive: bool = False,
+        ignore_missing: bool = False,
+    ) -> None:
 
         self._previous = None
         self._next = None
@@ -34,7 +38,7 @@ class Config:
         if keys is None:
             keys = self.__class__.__name__
         # check if keys is empty, set to empty list, results in not looking for sub structs
-        elif isinstance(keys, str) and keys == '':
+        elif isinstance(keys, str) and keys == "":
             keys = []
 
         # check is config is a string representation of a dictionary
@@ -42,7 +46,7 @@ class Config:
             try:
                 config = json.loads(config)
             except json.JSONDecodeError:
-                logger.debug('Unsuccessful loading config as string rep of dict')
+                logger.debug("Unsuccessful loading config as string rep of dict")
 
         # if config is a string use it to find filepaths
         if isinstance(config, str):
@@ -60,8 +64,8 @@ class Config:
         # check for all expected config attributes
         if not ignore_missing:
             for key, value in self.__dict__.items():
-                if value is None and key not in ['_next', '_previous']:
-                    raise NameError(f'name ({key}) not found in config')
+                if value is None and key not in ["_next", "_previous"]:
+                    raise NameError(f"name ({key}) not found in config")
 
     @property
     def first(self) -> Self:
@@ -88,12 +92,11 @@ class Config:
         return self._next.last
 
     def _load_from_filepath(self, filepath: str) -> dict:
-        with open(filepath, 'r', encoding='utf8') as file:
+        with open(filepath, "r", encoding="utf8") as file:
             return json.load(file)
 
     def _from_filepaths(self, filepaths: Iterable[str], keys: str) -> Self:
-        config_dicts = [self._load_from_filepath(filepath)
-                        for filepath in filepaths]
+        config_dicts = [self._load_from_filepath(filepath) for filepath in filepaths]
         self._from_config_dicts(config_dicts, keys)
 
     def _from_config_dict(self, config_dict: dict, keys: str) -> Self:

--- a/python/idsse_common/idsse/common/http_utils.py
+++ b/python/idsse_common/idsse/common/http_utils.py
@@ -1,4 +1,5 @@
 """Helper function for listing directories and retrieving s3 objects"""
+
 # -------------------------------------------------------------------------------
 # Created on Tue Dec 3 2024
 #
@@ -20,9 +21,9 @@ from .protocol_utils import ProtocolUtils
 
 logger = logging.getLogger(__name__)
 
+
 class HttpUtils(ProtocolUtils):
     """http Utility Class - Used by DAS for file downloads"""
-
 
     def ls(self, path: str, prepend_path: bool = True) -> Sequence[str]:
         """Execute a 'ls' on the http(s) server
@@ -42,12 +43,14 @@ class HttpUtils(ProtocolUtils):
                     filename = line.split('href="')[1].split('"')[0]
 
                     # Exclude directories and file without expected suffix
-                    if not filename.endswith('/') and filename.endswith(self.path_builder.file_ext):
+                    if not filename.endswith("/") and filename.endswith(
+                        self.path_builder.file_ext
+                    ):
                         files.append(filename)
 
         except requests.exceptions.RequestException as exp:
             if "403" not in str(exp):
-                logger.warning('Unable to query supplied Path : %s', str(exp))
+                logger.warning("Unable to query supplied Path : %s", str(exp))
             return []
         files = sorted(files, reverse=True)
         if prepend_path:
@@ -55,11 +58,9 @@ class HttpUtils(ProtocolUtils):
         return files
 
     # pylint: disable=unused-argument
-    def cp(self,
-           path: str,
-           dest: str,
-           concurrency: int | None = None,
-           chunk_size: int | None = None) -> bool:
+    def cp(
+        self, path: str, dest: str, concurrency: int | None = None, chunk_size: int | None = None
+    ) -> bool:
         """Execute http request download from path to dest.
 
         Args:
@@ -82,8 +83,8 @@ class HttpUtils(ProtocolUtils):
                         shutil.copyfileobj(response.raw, file)
                     return True
 
-                logger.info('copy fail: request status code: %s', response.status_code)
+                logger.info("copy fail: request status code: %s", response.status_code)
                 return False
         except Exception as e:  # pylint: disable=broad-exception-caught, invalid-name
-            logger.error('copy fail: exception %s', str(e))
+            logger.error("copy fail: exception %s", str(e))
             return False

--- a/python/idsse_common/idsse/common/json_message.py
+++ b/python/idsse_common/idsse/common/json_message.py
@@ -1,4 +1,5 @@
 """A module for managing the json messages used to communicate between services"""
+
 # ------------------------------------------------------------------------------
 # Created on Tue May 09 2023
 #
@@ -17,9 +18,7 @@ from uuid import UUID, uuid4
 Json = dict[str, Any] | Sequence[Any] | int | str | float | bool | None
 
 
-def get_corr_id(
-    message: str | dict
-) -> tuple[str | None, UUID | str | None, str | None] | None:
+def get_corr_id(message: str | dict) -> tuple[str | None, UUID | str | None, str | None] | None:
     """Extract the correlation id from a json message.
        The correlation id is made of three parts: originator, uuid, issue date/time
 
@@ -34,23 +33,27 @@ def get_corr_id(
     if isinstance(message, str):
         message = json.loads(message)
 
-    corr_id = message.get('corrId', None)
+    corr_id = message.get("corrId", None)
     if not corr_id:
         return corr_id
 
-    corr_id = (corr_id.get('originator', None),
-               corr_id.get('uuid', None),
-               corr_id.get('issueDt', None))
+    corr_id = (
+        corr_id.get("originator", None),
+        corr_id.get("uuid", None),
+        corr_id.get("issueDt", None),
+    )
 
     if any(corr_id):
         return corr_id
     return None
 
 
-def add_corr_id(message: dict | str,
-                originator: str,
-                uuid_: UUID | str | None = None,
-                issue_dt: str | None = None) -> dict:
+def add_corr_id(
+    message: dict | str,
+    originator: str,
+    uuid_: UUID | str | None = None,
+    issue_dt: str | None = None,
+) -> dict:
     """Add (or overwrites) the three part correlation id to a json message
 
     Args:
@@ -69,9 +72,7 @@ def add_corr_id(message: dict | str,
     if not uuid_:
         uuid_ = uuid4()
     if not issue_dt:
-        issue_dt = '_'
-    message['corrId'] = {'originator': originator,
-                         'uuid': f'{uuid_}',
-                         'issueDt': issue_dt}
+        issue_dt = "_"
+    message["corrId"] = {"originator": originator, "uuid": f"{uuid_}", "issueDt": issue_dt}
 
     return message

--- a/python/idsse_common/idsse/common/path_builder.py
+++ b/python/idsse_common/idsse/common/path_builder.py
@@ -6,6 +6,7 @@ In this weather forecasting data context,
 - lead: the time duration (often in hours) between issue and valid, a sort of forecast "lifespan"
 
 """
+
 # -------------------------------------------------------------------------------
 # Created on Thu Feb 16 2023
 #
@@ -29,18 +30,14 @@ from .utils import TimeDelta
 class PathBuilder:
     """Path Builder Class"""
 
-    ISSUE: Final[str] = 'issue'
-    VALID: Final[str] = 'valid'
-    LEAD: Final[str] = 'lead'
-    INT: Final[str] = 'd'
-    FLOAT: Final[str] = 'f'
-    STR: Final[str] = 's'
+    ISSUE: Final[str] = "issue"
+    VALID: Final[str] = "valid"
+    LEAD: Final[str] = "lead"
+    INT: Final[str] = "d"
+    FLOAT: Final[str] = "f"
+    STR: Final[str] = "s"
 
-    def __init__(self,
-                 basedir: str,
-                 subdir: str,
-                 file_base: str,
-                 file_ext: str) -> None:
+    def __init__(self, basedir: str, subdir: str, file_base: str, file_ext: str) -> None:
 
         # store path format parts to private vars, they accessible via properties
         self._base_dir = basedir
@@ -60,8 +57,10 @@ class PathBuilder:
         return f"'{self._base_dir}','{self._sub_dir}','{self._file_base}','{self._file_ext}'"
 
     def __repr__(self) -> str:
-        return (f"PathBuilder(basedir='{self._base_dir}', subdir='{self._sub_dir}', "
-                f"file_base='{self._file_base}', file_ext='{self._file_ext}')")
+        return (
+            f"PathBuilder(basedir='{self._base_dir}', subdir='{self._sub_dir}', "
+            f"file_base='{self._file_base}', file_ext='{self._file_ext}')"
+        )
 
     @classmethod
     def from_dir_filename(cls, dir_fmt: str, filename_fmt: str) -> Self:
@@ -79,7 +78,7 @@ class PathBuilder:
         Returns:
             Self: The newly created PathBuilder object
         """
-        return PathBuilder(dir_fmt, '', filename_fmt, '')
+        return PathBuilder(dir_fmt, "", filename_fmt, "")
 
     @classmethod
     def from_path(cls, path_fmt: str) -> Self:
@@ -92,7 +91,7 @@ class PathBuilder:
             Self: The newly created PathBuilder object
         """
         idx = path_fmt.rindex(os.path.sep)
-        return PathBuilder(path_fmt[:idx], '', path_fmt[idx+1:], '')
+        return PathBuilder(path_fmt[:idx], "", path_fmt[idx + 1 :], "")
 
     @property
     def dir_fmt(self):
@@ -102,9 +101,9 @@ class PathBuilder:
     @property
     def filename_fmt(self):
         """Provides access to the filename format string"""
-        if not self.file_ext or self.file_ext.startswith('.'):
-            return f'{self.file_base}{self.file_ext}'
-        return f'{self.file_base}.{self.file_ext}'
+        if not self.file_ext or self.file_ext.startswith("."):
+            return f"{self.file_base}{self.file_ext}"
+        return f"{self.file_base}.{self.file_ext}"
 
     @property
     def path_fmt(self):
@@ -152,7 +151,7 @@ class PathBuilder:
         """Provides access to the file extension format string"""
         if self._file_ext:
             return self._file_ext
-        return self._file_base[self._file_base.rindex('.'):]
+        return self._file_base[self._file_base.rindex(".") :]
 
     @file_ext.setter
     def file_ext(self, ext):
@@ -161,11 +160,13 @@ class PathBuilder:
         self._file_ext = ext
         self._update_lookup(self.path_fmt)
 
-    def build_dir(self,
-                  issue: datetime | None = None,
-                  valid: datetime | None = None,
-                  lead: timedelta | TimeDelta | None = None,
-                  **kwargs) -> str:
+    def build_dir(
+        self,
+        issue: datetime | None = None,
+        valid: datetime | None = None,
+        lead: timedelta | TimeDelta | None = None,
+        **kwargs,
+    ) -> str:
         """Attempts to build the directory with provided arguments
 
         Args:
@@ -185,11 +186,13 @@ class PathBuilder:
         lead = self._ensure_lead(issue, valid, lead)
         return self.dir_fmt.format(issue=issue, valid=valid, lead=lead, **kwargs)
 
-    def build_filename(self,
-                       issue: datetime | None = None,
-                       valid: datetime | None = None,
-                       lead: timedelta | TimeDelta | None = None,
-                       **kwargs) -> str:
+    def build_filename(
+        self,
+        issue: datetime | None = None,
+        valid: datetime | None = None,
+        lead: timedelta | TimeDelta | None = None,
+        **kwargs,
+    ) -> str:
         """Attempts to build the filename with provided arguments
 
         Args:
@@ -207,11 +210,13 @@ class PathBuilder:
         lead = self._ensure_lead(issue, valid, lead)
         return self.filename_fmt.format(issue=issue, valid=valid, lead=lead, **kwargs)
 
-    def build_path(self,
-                   issue: datetime | None = None,
-                   valid: datetime | None = None,
-                   lead: timedelta | TimeDelta | None = None,
-                   **kwargs: dict) -> str:
+    def build_path(
+        self,
+        issue: datetime | None = None,
+        valid: datetime | None = None,
+        lead: timedelta | TimeDelta | None = None,
+        **kwargs: dict,
+    ) -> str:
         """Attempts to build the path with provided arguments
 
         Args:
@@ -313,34 +318,39 @@ class PathBuilder:
             remaining_fmt_part = fmt_part
             lookup_info = []
             cum_start = 0
-            while (re_match := re.search(r'\{(.*?)\}', remaining_fmt_part)):
-                arg_parts = re_match.group()[1:-1].split(':')
+            while re_match := re.search(r"\{(.*?)\}", remaining_fmt_part):
+                arg_parts = re_match.group()[1:-1].split(":")
                 if len(arg_parts) != 2:
-                    raise ValueError('Format string must have explicit specification '
-                                     '(must include a ":")')
+                    raise ValueError(
+                        'Format string must have explicit specification (must include a ":")'
+                    )
                 try:
-                    arg_size = int(re.search(r'^\d+', arg_parts[1]).group())
+                    arg_size = int(re.search(r"^\d+", arg_parts[1]).group())
                 except Exception:
                     # pylint: disable=raise-missing-from
-                    raise ValueError('Format string must have explicit size '
-                                     '(must include a number after ":")')
+                    raise ValueError(
+                        'Format string must have explicit size (must include a number after ":")'
+                    )
                 arg_type = arg_parts[1][-1]
                 if arg_parts[1][-1] not in [self.INT, self.FLOAT, self.STR]:
-                    raise ValueError('Format string must have explicit type (must include one of '
-                                     f'["{self.INT}", "{self.FLOAT}", "{self.STR}"] after ":")')
+                    raise ValueError(
+                        "Format string must have explicit type (must include one of "
+                        f'["{self.INT}", "{self.FLOAT}", "{self.STR}"] after ":")'
+                    )
 
                 arg_start = re_match.start() + cum_start
                 arg_end = cum_start = arg_start + arg_size
                 lookup_info.append(_LookupInfo(arg_parts[0], arg_start, arg_end, arg_type))
                 # update the format str to find the next argument
-                remaining_fmt_part = remaining_fmt_part[re_match.end():]
+                remaining_fmt_part = remaining_fmt_part[re_match.end() :]
 
-            exp_len = (sum(end-start for _, start, end, _ in lookup_info) +
-                       len(re.sub(r'\{(.*?)\}', '', fmt_part)))
+            exp_len = sum(end - start for _, start, end, _ in lookup_info) + len(
+                re.sub(r"\{(.*?)\}", "", fmt_part)
+            )
 
             self._lookup_dict[fmt_part] = _FormatLookup(exp_len, lookup_info)
         # add default for empty string
-        self._lookup_dict[''] = _FormatLookup(0, [])
+        self._lookup_dict[""] = _FormatLookup(0, [])
 
     def _parse_path(self, path: str, fmt_str: str) -> None:
         """Parse a path for any knowable variables given the provided format string.
@@ -388,21 +398,27 @@ class PathBuilder:
         for path_part, fmt_part in zip(path_parts, fmt_parts):
             expected_len, lookup_info = self._lookup_dict[fmt_part]
             if (part_len := len(path_part)) != expected_len:
-                raise ValueError('Path is not expected length. Passed path part '
-                                 f"'{path_part}' doesn't match format '{fmt_part}'")
+                raise ValueError(
+                    "Path is not expected length. Passed path part "
+                    f"'{path_part}' doesn't match format '{fmt_part}'"
+                )
             for lookup in lookup_info:
                 if not (0 <= lookup.start <= part_len and 0 <= lookup.end <= part_len):
-                    raise ValueError('Parse indices are out of range for path')
+                    raise ValueError("Parse indices are out of range for path")
                 try:
                     match lookup.type:
                         case self.INT:
-                            parsed_arg_parts[lookup.key] = int(path_part[lookup.start:lookup.end])
+                            parsed_arg_parts[lookup.key] = int(
+                                path_part[lookup.start : lookup.end]
+                            )
                         case self.FLOAT:
-                            parsed_arg_parts[lookup.key] = float(path_part[lookup.start:lookup.end])
+                            parsed_arg_parts[lookup.key] = float(
+                                path_part[lookup.start : lookup.end]
+                            )
                         case self.STR:
-                            parsed_arg_parts[lookup.key] = path_part[lookup.start:lookup.end]
+                            parsed_arg_parts[lookup.key] = path_part[lookup.start : lookup.end]
                 except ValueError as exc:
-                    raise ValueError('Unable to apply formatting') from exc
+                    raise ValueError("Unable to apply formatting") from exc
         return parsed_arg_parts
 
     def _apply_format(self, fmt_str: str, **kwargs) -> str:
@@ -425,14 +441,16 @@ class PathBuilder:
             if len(path_part) == self._lookup_dict[fmt_part].exp_len:
                 path_parts.append(path_part)
             else:
-                raise ValueError('Arguments generate a path that violate '
-                                 f"at least part of the format, part '{fmt_part}'")
+                raise ValueError(
+                    "Arguments generate a path that violate "
+                    f"at least part of the format, part '{fmt_part}'"
+                )
         return os.path.sep.join(path_parts)
 
     @staticmethod
-    def _get_issue_from_arg_parts(parsed_args: dict,
-                                  valid: datetime | None = None,
-                                  lead: timedelta | None = None) -> datetime:
+    def _get_issue_from_arg_parts(
+        parsed_args: dict, valid: datetime | None = None, lead: timedelta | None = None
+    ) -> datetime:
         """Static method for creating an issue date/time from parsed arguments and optional inputs
 
         Args:
@@ -446,27 +464,29 @@ class PathBuilder:
         Returns:
             datetime: Issue date/time
         """
-        if 'issue.year' in parsed_args:
-            return datetime(parsed_args.get('issue.year'),
-                            parsed_args.get('issue.month'),
-                            parsed_args.get('issue.day'),
-                            parsed_args.get('issue.hour', 0),
-                            parsed_args.get('issue.minute', 0),
-                            parsed_args.get('issue.second', 0),
-                            parsed_args.get('issue.microsecond', 0),
-                            tzinfo=UTC)
-        if lead is None and 'lead.hour' in parsed_args:
+        if "issue.year" in parsed_args:
+            return datetime(
+                parsed_args.get("issue.year"),
+                parsed_args.get("issue.month"),
+                parsed_args.get("issue.day"),
+                parsed_args.get("issue.hour", 0),
+                parsed_args.get("issue.minute", 0),
+                parsed_args.get("issue.second", 0),
+                parsed_args.get("issue.microsecond", 0),
+                tzinfo=UTC,
+            )
+        if lead is None and "lead.hour" in parsed_args:
             lead = PathBuilder._get_lead_from_time_args(parsed_args)
-        if valid is None and 'valid.year' in parsed_args:
+        if valid is None and "valid.year" in parsed_args:
             valid = PathBuilder._get_valid_from_arg_parts(parsed_args)
         if valid and lead:
             return valid - lead
         return None
 
     @staticmethod
-    def _get_valid_from_arg_parts(parsed_args: dict,
-                                  issue: datetime | None = None,
-                                  lead: timedelta | None = None) -> datetime:
+    def _get_valid_from_arg_parts(
+        parsed_args: dict, issue: datetime | None = None, lead: timedelta | None = None
+    ) -> datetime:
         """Static method for creating a valid date/time from parsed arguments and optional inputs
 
         Args:
@@ -480,18 +500,20 @@ class PathBuilder:
         Returns:
             datetime: Valid date/time
         """
-        if 'valid.year' in parsed_args:
-            return datetime(parsed_args.get('valid.year'),
-                            parsed_args.get('valid.month'),
-                            parsed_args.get('valid.day'),
-                            parsed_args.get('valid.hour', 0),
-                            parsed_args.get('valid.minute', 0),
-                            parsed_args.get('valid.second', 0),
-                            parsed_args.get('valid.microsecond', 0),
-                            tzinfo=UTC)
-        if lead is None and 'lead.hour' in parsed_args:
+        if "valid.year" in parsed_args:
+            return datetime(
+                parsed_args.get("valid.year"),
+                parsed_args.get("valid.month"),
+                parsed_args.get("valid.day"),
+                parsed_args.get("valid.hour", 0),
+                parsed_args.get("valid.minute", 0),
+                parsed_args.get("valid.second", 0),
+                parsed_args.get("valid.microsecond", 0),
+                tzinfo=UTC,
+            )
+        if lead is None and "lead.hour" in parsed_args:
             lead = PathBuilder._get_lead_from_time_args(parsed_args)
-        if issue is None and 'issue.year' in parsed_args:
+        if issue is None and "issue.year" in parsed_args:
             issue = PathBuilder._get_issue_from_arg_parts(parsed_args)
         if issue and lead:
             return issue + lead
@@ -508,14 +530,14 @@ class PathBuilder:
         Returns:
             timedelta: Lead time
         """
-        if 'lead.hour' in time_args.keys():
-            return timedelta(hours=time_args['lead.hour'])
+        if "lead.hour" in time_args.keys():
+            return timedelta(hours=time_args["lead.hour"])
         return None
 
     @staticmethod
-    def _ensure_lead(issue: datetime | None,
-                     valid: datetime | None,
-                     lead: timedelta | TimeDelta | None) -> TimeDelta:
+    def _ensure_lead(
+        issue: datetime | None, valid: datetime | None, lead: timedelta | TimeDelta | None
+    ) -> TimeDelta:
         """Make every attempt to ensure lead is known, by calculating or converting if needed.
 
         Args:
@@ -531,13 +553,14 @@ class PathBuilder:
                 return TimeDelta(lead)
             return lead
         if issue and valid:
-            return TimeDelta(valid-issue)
+            return TimeDelta(valid - issue)
         return None
 
 
 # Private utility classes
 class _LookupInfo(NamedTuple):
     """Data class used to hold lookup info"""
+
     key: str
     start: int
     end: int
@@ -546,5 +569,6 @@ class _LookupInfo(NamedTuple):
 
 class _FormatLookup(NamedTuple):
     """Data class used to hold format and lookup info"""
+
     exp_len: int
     lookups: list[_LookupInfo]

--- a/python/idsse_common/idsse/common/protocol_utils.py
+++ b/python/idsse_common/idsse/common/protocol_utils.py
@@ -1,4 +1,5 @@
 """Base class for http and awc data access"""
+
 # -------------------------------------------------------------------------------
 # Created on Tue Dec 3 2024
 #
@@ -23,11 +24,7 @@ from .utils import TimeDelta, datetime_gen
 class ProtocolUtils(ABC):
     """Base Class - interface for DAS data discovery"""
 
-    def __init__(self,
-                 basedir: str,
-                 subdir: str,
-                 file_base: str,
-                 file_ext: str) -> None:
+    def __init__(self, basedir: str, subdir: str, file_base: str, file_ext: str) -> None:
         self.path_builder = PathBuilder(basedir, subdir, file_base, file_ext)
 
     # pylint: disable=invalid-name
@@ -65,7 +62,7 @@ class ProtocolUtils(ABC):
         Returns:
             str: Absolute path to file or object
         """
-        lead = TimeDelta(valid-issue)
+        lead = TimeDelta(valid - issue)
         return self.path_builder.build_path(issue=issue, valid=valid, lead=lead, **kwargs)
 
     def check_for(self, issue: datetime, valid: datetime, **kwargs) -> tuple[datetime, str] | None:
@@ -94,13 +91,14 @@ class ProtocolUtils(ABC):
                 return valid, os.path.join(dir_path, fname)
         return None
 
-    def get_issues(self,
-                   num_issues: int = 1,
-                   issue_start: datetime | None = None,
-                   issue_end: datetime | None = None,
-                   time_delta: timedelta = timedelta(hours=1),
-                   **kwargs
-                   ) -> Sequence[datetime]:
+    def get_issues(
+        self,
+        num_issues: int = 1,
+        issue_start: datetime | None = None,
+        issue_end: datetime | None = None,
+        time_delta: timedelta = timedelta(hours=1),
+        **kwargs
+    ) -> Sequence[datetime]:
         """Determine the available issue date/times
 
         Args:
@@ -115,7 +113,7 @@ class ProtocolUtils(ABC):
         """
         zero_time_delta = timedelta(seconds=0)
         if time_delta == zero_time_delta:
-            raise ValueError('Time delta must be non zero')
+            raise ValueError("Time delta must be non zero")
 
         if not issue_end:
             issue_end = datetime.now(UTC)
@@ -141,12 +139,13 @@ class ProtocolUtils(ABC):
             issues_set.remove(None)
         return sorted(issues_set)[:num_issues]
 
-    def get_valids(self,
-                   issue: datetime,
-                   valid_start: datetime | None = None,
-                   valid_end: datetime | None = None,
-                   **kwargs
-                   ) -> Sequence[tuple[datetime, str]]:
+    def get_valids(
+        self,
+        issue: datetime,
+        valid_start: datetime | None = None,
+        valid_end: datetime | None = None,
+        **kwargs
+    ) -> Sequence[tuple[datetime, str]]:
         """Get all objects consistent with the passed issue date/time and filter by valid range
 
         Args:
@@ -179,24 +178,23 @@ class ProtocolUtils(ABC):
         # Remove any tuple that has "None" as the valid time
         if valid_start:
             if valid_end:
-                valid_and_file = [(valid, filename)
-                                  for valid, filename in valid_and_file
-                                  if valid_start <= valid <= valid_end]
+                valid_and_file = [
+                    (valid, filename)
+                    for valid, filename in valid_and_file
+                    if valid_start <= valid <= valid_end
+                ]
             else:
-                valid_and_file = [(valid, filename)
-                                  for valid, filename in valid_and_file
-                                  if valid >= valid_start]
+                valid_and_file = [
+                    (valid, filename) for valid, filename in valid_and_file if valid >= valid_start
+                ]
         elif valid_end:
-            valid_and_file = [(valid, filename)
-                              for valid, filename in valid_and_file
-                              if valid <= valid_end]
+            valid_and_file = [
+                (valid, filename) for valid, filename in valid_and_file if valid <= valid_end
+            ]
 
         return valid_and_file
 
-    def _get_issues(self,
-                    dir_path: str,
-                    num_issues: int = 1
-                    ) -> set[datetime]:
+    def _get_issues(self, dir_path: str, num_issues: int = 1) -> set[datetime]:
         """Get all objects consistent with the passed directory path and filter by valid range
 
         Args:
@@ -211,9 +209,9 @@ class ProtocolUtils(ABC):
         issues_set: set[datetime] = set()
         # sort files alphabetically in reverse; this should give us the longest lead time first
         # which is more indicative that the issueDt is fully available on this server
-        filepaths = sorted((f for f in self.ls(dir_path)
-                            if f.endswith(self.path_builder.file_ext)),
-                           reverse=True)
+        filepaths = sorted(
+            (f for f in self.ls(dir_path) if f.endswith(self.path_builder.file_ext)), reverse=True
+        )
         for file_path in filepaths:
             try:
                 issues_set.add(self.path_builder.get_issue(file_path))

--- a/python/idsse_common/idsse/common/sci/bit_pack.py
+++ b/python/idsse_common/idsse/common/sci/bit_pack.py
@@ -1,4 +1,5 @@
 """Utility module for packing data"""
+
 # ----------------------------------------------------------------------------------
 # Created on Thu Dec 14 2023
 #
@@ -18,12 +19,14 @@ import numpy
 
 class PackType(IntEnum):
     """Enumerated type used to indicate if data is packed into a byte or short (16 bit)"""
+
     BYTE = 8
     SHORT = 16
 
 
 class PackInfo(NamedTuple):
     """Data class used to hold packing info"""
+
     type: PackType
     scale: float
     offset: float
@@ -31,6 +34,7 @@ class PackInfo(NamedTuple):
 
 class PackData(NamedTuple):
     """Data class used to hold packed data and the corresponding packing info"""
+
     type: PackType
     scale: float
     offset: float
@@ -50,17 +54,14 @@ def get_min_max(data: list | numpy.ndarray) -> tuple[float, float]:
         tuple[float, float]: The minimum, maximum from the supplied argument
     """
     if isinstance(data, list):
-        arr = numpy.array(data).ravel(order='K')
+        arr = numpy.array(data).ravel(order="K")
         return numpy.min(arr), numpy.max(arr)
-    data.ravel(order='K')
+    data.ravel(order="K")
     return numpy.min(data), numpy.max(data)
 
 
 def get_pack_info(
-        min_value: float,
-        max_value: float,
-        decimals: int = None,
-        pack_type: PackType = None
+    min_value: float, max_value: float, decimals: int = None, pack_type: PackType = None
 ) -> PackInfo:
     """Retrieve appropriate packing info based on min/max values and
     either decimals of precision or pack type.
@@ -84,29 +85,29 @@ def get_pack_info(
                   scale and offset.
     """
     if decimals is None and pack_type is None:
-        raise ValueError('Either decimals or pack_type must be non None')
+        raise ValueError("Either decimals or pack_type must be non None")
 
     if decimals is not None and pack_type is not None:
-        raise ValueError('Either decimals or pack_type must be non None, but not both')
+        raise ValueError("Either decimals or pack_type must be non None, but not both")
 
     if pack_type:
         scale = (max_value - min_value) / _max_values[pack_type]
         return PackInfo(pack_type, float(scale), float(min_value))
 
     scale = _get_scale(decimals)
-    unique_values = int((max_value-min_value) / scale)
+    unique_values = int((max_value - min_value) / scale)
     for p_type, max_val in _max_values.items():
         if unique_values <= max_val:
             return PackInfo(p_type, float(scale), float(min_value))
 
-    raise ValueError('Unable to find appropriate packing')
+    raise ValueError("Unable to find appropriate packing")
 
 
 def pack_to_list(
-        data: list | numpy.ndarray,
-        pack_info: PackInfo | None = None,
-        decimals: int | None = None,
-        in_place: bool = True
+    data: list | numpy.ndarray,
+    pack_info: PackInfo | None = None,
+    decimals: int | None = None,
+    in_place: bool = True,
 ):
     """Preform bit packing of input data, utilizing the the pack_info if provided or
     a derived pack_info if not.
@@ -132,14 +133,14 @@ def pack_to_list(
     if isinstance(data, list):
         return pack_list_to_list(data, pack_info, decimals, in_place)
 
-    raise KeyError(f'Data type ({type(data)}), is not supported')
+    raise KeyError(f"Data type ({type(data)}), is not supported")
 
 
 def pack_numpy_to_numpy(
-        data: numpy.ndarray,
-        pack_info: PackInfo | None = None,
-        decimals: int | None = None,
-        in_place: bool = True
+    data: numpy.ndarray,
+    pack_info: PackInfo | None = None,
+    decimals: int | None = None,
+    in_place: bool = True,
 ) -> PackData:
     """Preform bit packing of input data, utilizing the the pack_info if provided or
     a derived pack_info if not. Input and output are numpy arrays.
@@ -160,17 +161,16 @@ def pack_numpy_to_numpy(
                   numpy array.
     """
     if not isinstance(data, numpy.ndarray):
-        raise ValueError(f'Data must be a numpy.ndarray but is of type {type(data)}')
+        raise ValueError(f"Data must be a numpy.ndarray but is of type {type(data)}")
 
     pack_type, scale, offset = _resolve_pack_info(data, pack_info, decimals)
 
     if in_place:
         if not numpy.issubdtype(data.dtype, numpy.floating):
-            raise ValueError('Can not complete "in_place" bit packing with '
-                             'non floating point array')
+            raise ValueError("Cannot complete in_place bit packing with non floating point array")
         data -= offset
     else:
-        data = data-offset
+        data = data - offset
 
     data /= scale
     data += 0.5  # for non-negative values adding .5 before truncation is equivalent to round
@@ -178,10 +178,10 @@ def pack_numpy_to_numpy(
 
 
 def pack_list_to_list(
-        data: list,
-        pack_info: PackInfo | None = None,
-        decimals: int | None = None,
-        in_place: bool = True
+    data: list,
+    pack_info: PackInfo | None = None,
+    decimals: int | None = None,
+    in_place: bool = True,
 ) -> PackData:
     """Preform bit-packing of input data, utilizing the pack_info if provided or
     a derived pack_info if not. Input and output are python list (can be nested lists).
@@ -202,7 +202,7 @@ def pack_list_to_list(
                   python list (possibly nested).
     """
     if not isinstance(data, list):
-        raise ValueError(f'Data must be a python list but is of type {type(data)}')
+        raise ValueError(f"Data must be a python list but is of type {type(data)}")
 
     pack_type, scale, offset = _resolve_pack_info(data, pack_info, decimals)
     if in_place:
@@ -211,9 +211,9 @@ def pack_list_to_list(
 
 
 def pack_numpy_to_list(
-        data: numpy.array,
-        pack_info: PackInfo | None = None,
-        decimals: int | None = None,
+    data: numpy.array,
+    pack_info: PackInfo | None = None,
+    decimals: int | None = None,
 ) -> PackData:
     """Preform bit packing of input data, utilizing the the pack_info if provided or
     a derived pack_info if not. Input is numpy array and output is python list.
@@ -232,7 +232,7 @@ def pack_numpy_to_list(
                   python list.
     """
     if not isinstance(data, numpy.ndarray):
-        raise ValueError(f'Data must be a numpy.ndarray but is of type {type(data)}')
+        raise ValueError(f"Data must be a numpy.ndarray but is of type {type(data)}")
 
     pack_type, scale, offset = _resolve_pack_info(data, pack_info, decimals)
     return PackData(pack_type, scale, offset, _pack_np_array_to_list(data, scale, offset))
@@ -245,30 +245,21 @@ def pack_numpy_to_list(
 # create a pack_info), or lastly if not providing a pack_info or decimal then a pack_info using
 # short packing would be used.
 def _resolve_pack_info(
-        data,
-        pack_info: PackInfo | None = None,
-        decimals: int | None = None
+    data, pack_info: PackInfo | None = None, decimals: int | None = None
 ) -> PackInfo:
-    return (PackInfo(pack_info.type,
-                     float(pack_info.scale),
-                     float(pack_info.offset))
-            if pack_info is not None
-            else get_pack_info(numpy.min(data),
-                               numpy.max(data),
-                               decimals=decimals)
+    return (
+        PackInfo(pack_info.type, float(pack_info.scale), float(pack_info.offset))
+        if pack_info is not None
+        else (
+            get_pack_info(numpy.min(data), numpy.max(data), decimals=decimals)
             if decimals is not None
-            else get_pack_info(numpy.min(data),
-                               numpy.max(data),
-                               pack_type=PackType.SHORT)
-            )
+            else get_pack_info(numpy.min(data), numpy.max(data), pack_type=PackType.SHORT)
+        )
+    )
 
 
 # core packing code specific to in place packing of a list(s)
-def _pack_list_to_list_in_place(
-        data: list,
-        scale: float,
-        offset: float
-) -> list:
+def _pack_list_to_list_in_place(data: list, scale: float, offset: float) -> list:
     # Convert list into numpy array (it creates a copy)
     np_data = numpy.array(data, dtype=float)
     data = _pack_np_array_to_list(np_data, scale, offset)
@@ -276,21 +267,13 @@ def _pack_list_to_list_in_place(
 
 
 # core packing code specific to packing a list(s) with forced copying
-def _pack_list_to_list_copy(
-        data: list,
-        scale: float,
-        offset: float
-) -> list:
+def _pack_list_to_list_copy(data: list, scale: float, offset: float) -> list:
     np_data = numpy.array(data, dtype=float)
     return _pack_np_array_to_list(np_data, scale, offset)
 
 
 # core packing code specific to packing numpy array to a list, in place not possible
-def _pack_np_array_to_list(
-        data: numpy.array,
-        scale: float,
-        offset: float
-) -> list:
+def _pack_np_array_to_list(data: numpy.array, scale: float, offset: float) -> list:
     np_data = numpy.copy(data)
     np_data -= offset
     np_data /= scale
@@ -298,6 +281,7 @@ def _pack_np_array_to_list(
     np_data += 0.5
     # Return the truncated array and a int list.
     return (numpy.trunc(np_data).astype(int)).tolist()
+
 
 # core packing code using diplib package (sometimes slower than the original so not used but here
 # for an option.
@@ -311,23 +295,12 @@ def _pack_np_array_to_list(
 
 
 # private lookup for the max value possible for bit packing type
-_max_values = {
-    PackType.BYTE: 255,
-    PackType.SHORT: 65535
-}
+_max_values = {PackType.BYTE: 255, PackType.SHORT: 65535}
 
-_scale_lookup = {
-    0: 1.,
-    1: 0.1,
-    2: 0.01,
-    3: 0.001,
-    4: 0.0001,
-    5: 0.00001,
-    6: 0.000001
-}
+_scale_lookup = {0: 1.0, 1: 0.1, 2: 0.01, 3: 0.001, 4: 0.0001, 5: 0.00001, 6: 0.000001}
 
 
 # private lookup function of num decimal to actual decimals. Using the lookup remove rounding
 # issues with math.pow for the most common decimal values
 def _get_scale(decimals):
-    return _scale_lookup.get(decimals, .1**decimals)
+    return _scale_lookup.get(decimals, 0.1**decimals)

--- a/python/idsse_common/idsse/common/sci/netcdf_io.py
+++ b/python/idsse_common/idsse/common/sci/netcdf_io.py
@@ -1,4 +1,5 @@
 """Utilities for reading NetCDF files"""
+
 # ----------------------------------------------------------------------------------
 # Created on Mon Feb 13 2023
 #
@@ -26,6 +27,7 @@ logger = logging.getLogger(__name__)
 # cSpell:ignore ncattrs, getncattr, maskandscale
 class HasNcAttr(Protocol):
     """Protocol that allows retrieving attributes"""
+
     def ncattrs(self) -> Sequence[str]:
         """Gives access to list of keys
 
@@ -68,23 +70,20 @@ def read_netcdf(filepath: str, use_h5_lib: bool = False) -> tuple[dict, np.ndarr
         tuple[dict, np.ndarray]: Global attributes and data
     """
     if use_h5_lib:
-        with h5nc.File(filepath, 'r') as nc_file:
-            grid = nc_file.variables['grid'][:]
+        with h5nc.File(filepath, "r") as nc_file:
+            grid = nc_file.variables["grid"][:]
             return nc_file.attrs, grid
 
     # otherwise, use netcdf4 library (default)
     with Dataset(filepath) as dataset:
         dataset.set_auto_maskandscale(False)
-        grid = dataset.variables['grid'][:]
+        grid = dataset.variables["grid"][:]
 
         global_attrs = _read_attrs(dataset)
         return global_attrs, grid
 
 
-def write_netcdf(attrs: dict,
-                 grid: np.ndarray,
-                 filepath: str,
-                 use_h5_lib: bool = False) -> str:
+def write_netcdf(attrs: dict, grid: np.ndarray, filepath: str, use_h5_lib: bool = False) -> str:
     """Store data and attributes to a Netcdf4 file
 
     Args:
@@ -101,14 +100,14 @@ def write_netcdf(attrs: dict,
     dirname = os.path.dirname(os.path.abspath(filepath))
     os.makedirs(dirname, exist_ok=True)
 
-    logger.debug('Writing data to: %s', filepath)
+    logger.debug("Writing data to: %s", filepath)
     if use_h5_lib:
-        with h5nc.File(filepath, 'w') as file:
+        with h5nc.File(filepath, "w") as file:
             y_dimensions, x_dimensions = grid.shape
             # set dimensions with a dictionary
-            file.dimensions = {'x': x_dimensions, 'y': y_dimensions}
+            file.dimensions = {"x": x_dimensions, "y": y_dimensions}
 
-            grid_var = file.create_variable('grid', ('y', 'x'), 'f4')
+            grid_var = file.create_variable("grid", ("y", "x"), "f4")
             grid_var[:] = grid
 
             for key, value in attrs.items():
@@ -117,12 +116,12 @@ def write_netcdf(attrs: dict,
         return filepath
 
     # otherwise, write file using netCDF4 library (default)
-    with Dataset(filepath, 'w', format='NETCDF4') as dataset:
+    with Dataset(filepath, "w", format="NETCDF4") as dataset:
         y_dimensions, x_dimensions = grid.shape
-        dataset.createDimension('x', x_dimensions)
-        dataset.createDimension('y', y_dimensions)
+        dataset.createDimension("x", x_dimensions)
+        dataset.createDimension("y", y_dimensions)
 
-        grid_var = dataset.createVariable('grid', 'f4', ('y', 'x'))
+        grid_var = dataset.createVariable("grid", "f4", ("y", "x"))
         grid_var[:] = grid
 
         for key, value in attrs.items():

--- a/python/idsse_common/idsse/common/sci/utils.py
+++ b/python/idsse_common/idsse/common/sci/utils.py
@@ -1,4 +1,5 @@
 """A collection of useful classes and utility functions involving scientific libraries"""
+
 # -----------------------------------------------------------------------------------
 # Created on Wed Jan 24 2024
 #
@@ -15,14 +16,15 @@ from collections.abc import Sequence
 from typing import NewType
 
 import numpy
+
 # import shapely
 
 logger = logging.getLogger(__name__)
 
 # type aliases
-Pixel = NewType('Pixel', Sequence[int])
-Coord = NewType('Coord', Sequence[float])
-Coords = NewType('Coords', Sequence[Coord])
+Pixel = NewType("Pixel", Sequence[int])
+Coord = NewType("Coord", Sequence[float])
+Coords = NewType("Coords", Sequence[Coord])
 
 
 def coordinate_pairs_to_axes(

--- a/python/idsse_common/idsse/common/validate_schema.py
+++ b/python/idsse_common/idsse/common/validate_schema.py
@@ -1,4 +1,5 @@
 """Class for validating IDSSe JSON messages against schema"""
+
 # ----------------------------------------------------------------------------------
 # Created on Mon Aug 07 2023
 #
@@ -26,8 +27,8 @@ def _get_refs(json_obj: dict | list, result: set | None = None) -> set:
         result = set()
     if isinstance(json_obj, dict):
         for key, value in json_obj.items():
-            if key == '$ref':
-                idx = value.index('#/')
+            if key == "$ref":
+                idx = value.index("#/")
                 if idx > 0:
                     result.add(value[:idx])
             else:
@@ -49,9 +50,9 @@ def get_validator(schema_name) -> Validator:
         Validator: A validator loaded with schema and all dependencies
     """
     current_path = os.path.dirname(os.path.realpath(__file__))
-    schema_dir = os.path.join(current_path, 'schema')
-    schema_filename = os.path.join(schema_dir, schema_name+'.json')
-    with open(schema_filename, 'r', encoding='utf8') as file:
+    schema_dir = os.path.join(current_path, "schema")
+    schema_filename = os.path.join(schema_dir, schema_name + ".json")
+    with open(schema_filename, "r", encoding="utf8") as file:
         schema: dict = json.load(file)
 
     dependencies = {}
@@ -60,13 +61,15 @@ def get_validator(schema_name) -> Validator:
         new_refs = set()
         for ref in refs:
             schema_filename = os.path.join(schema_dir, ref)
-            with open(schema_filename, 'r', encoding='utf8') as file:
+            with open(schema_filename, "r", encoding="utf8") as file:
                 ref_schema: dict = json.load(file)
-            dependencies[ref_schema.get('$id', ref)] = _draft.create_resource(ref_schema)
+            dependencies[ref_schema.get("$id", ref)] = _draft.create_resource(ref_schema)
             new_refs = _get_refs(ref_schema, new_refs)
         refs = {ref for ref in new_refs if ref not in dependencies}
 
     # used default Validator type
-    return _validator(schema=schema,
-                      registry=Registry().with_resources(dependencies.items()),
-                      format_checker=FormatChecker())
+    return _validator(
+        schema=schema,
+        registry=Registry().with_resources(dependencies.items()),
+        format_checker=FormatChecker(),
+    )

--- a/python/idsse_common/setup.py
+++ b/python/idsse_common/setup.py
@@ -1,32 +1,36 @@
 """Setup to support installation as Python library"""
+
 import glob
 from setuptools import setup
 
-setup(name='idsse',
-      version='1.0',
-      description='IDSSe Common',
-      url='',
-      author='WIDS',
-      author_email='@noaa.gov',
-      license='MIT',
-      python_requires=">=3.11",
-      packages=['idsse.common', 'idsse.common.schema', 'idsse.common.sci'],
-      data_files=[('idsse/common/schema', glob.glob('idsse/common/schema/*.json')),
-                  ('idsse/common/sci/resources', glob.glob('idsse/common/sci/resources/*.json'))],
-      include_package_data=True,
-      package_data={'':['schema/*.json']},
-      install_requires=[
-        'pint',
-        'importlib_metadata',
-        'pika',
-        'jsonschema',
-        'python-logging-rabbitmq'
-      ],
-      extras_require={
-        'develop': [
-          'pytest',
-          'pytest-cov',
+setup(
+    name="idsse",
+    version="1.0",
+    description="IDSSe Common",
+    url="",
+    author="WIDS",
+    author_email="@noaa.gov",
+    license="MIT",
+    python_requires=">=3.11",
+    packages=["idsse.common", "idsse.common.schema", "idsse.common.sci"],
+    data_files=[
+        ("idsse/common/schema", glob.glob("idsse/common/schema/*.json")),
+        ("idsse/common/sci/resources", glob.glob("idsse/common/sci/resources/*.json")),
+    ],
+    include_package_data=True,
+    package_data={"": ["schema/*.json"]},
+    install_requires=[
+        "pint",
+        "importlib_metadata",
+        "pika",
+        "jsonschema",
+        "python-logging-rabbitmq",
+    ],
+    extras_require={
+        "develop": [
+            "pytest",
+            "pytest-cov",
         ]
-      },
-      zip_safe=False,
+    },
+    zip_safe=False,
 )

--- a/python/idsse_common/test/sci/test_bit_pack.py
+++ b/python/idsse_common/test/sci/test_bit_pack.py
@@ -1,4 +1,5 @@
-'''Module for testing the bit pack utils'''
+"""Module for testing the bit pack utils"""
+
 # ----------------------------------------------------------------------------------
 # Created on Fri Dec 15 2023
 #
@@ -15,13 +16,15 @@
 import numpy
 import pytest
 
-from idsse.common.sci.bit_pack import (get_pack_info,
-                                       get_min_max,
-                                       pack_numpy_to_numpy,
-                                       pack_numpy_to_list,
-                                       pack_to_list,
-                                       PackInfo,
-                                       PackType)
+from idsse.common.sci.bit_pack import (
+    get_pack_info,
+    get_min_max,
+    pack_numpy_to_numpy,
+    pack_numpy_to_list,
+    pack_to_list,
+    PackInfo,
+    PackType,
+)
 
 
 def test_get_min_max():
@@ -83,10 +86,9 @@ def test_pack_list_to_list():
 
 
 def test_pack_numpy():
-    data = numpy.array([[-1, -.5, 0, .5, 1], [-1, -.25, 0, .25, 1]])
+    data = numpy.array([[-1, -0.5, 0, 0.5, 1], [-1, -0.25, 0, 0.25, 1]])
     result = pack_numpy_to_numpy(data, in_place=False)
-    expected = numpy.array([[0, 16384, 32768, 49151, 65535],
-                            [0, 24576, 32768, 40959, 65535]])
+    expected = numpy.array([[0, 16384, 32768, 49151, 65535], [0, 24576, 32768, 40959, 65535]])
     numpy.testing.assert_array_equal(result.data, expected)
     assert data[0, 0] != result.data[0, 0]
 
@@ -98,19 +100,19 @@ def test_pack_numpy():
 
 
 def test_pack_numpy_in_place():
-    data = numpy.array([[-100., -50, 0, 50, 100], [-100, 0, 100, 200, 300]])
+    data = numpy.array([[-100.0, -50, 0, 50, 100], [-100, 0, 100, 200, 300]])
     result = pack_numpy_to_numpy(data, in_place=True)
-    expected = numpy.array([[0.,  8191., 16383., 24575., 32767.],
-                            [0., 16383., 32767., 49151., 65535.]])
+    expected = numpy.array(
+        [[0.0, 8191.0, 16383.0, 24575.0, 32767.0], [0.0, 16383.0, 32767.0, 49151.0, 65535.0]]
+    )
     numpy.testing.assert_array_equal(data, result.data, expected)
     assert data[0, 0] == result.data[0, 0]
 
 
 def test_pack_numpy_to_list():
-    data = numpy.array([[-1, -.5, 0, .5, 1], [-1, -.25, 0, .25, 1]])
+    data = numpy.array([[-1, -0.5, 0, 0.5, 1], [-1, -0.25, 0, 0.25, 1]])
     result = pack_numpy_to_list(data, decimals=2)
-    expected = [[0, 50, 100, 150, 200],
-                [0, 75, 100, 125, 200]]
+    expected = [[0, 50, 100, 150, 200], [0, 75, 100, 125, 200]]
     assert isinstance(result.data, list)
     assert isinstance(result.data[0][0], int)
     numpy.testing.assert_array_equal(result.data, expected)

--- a/python/idsse_common/test/sci/test_geo_image.py
+++ b/python/idsse_common/test/sci/test_geo_image.py
@@ -1,4 +1,5 @@
 """Test suite for image_utils.py"""
+
 # ----------------------------------------------------------------------------------
 # Created on Fri Dec 29 2023
 #
@@ -21,17 +22,15 @@ from idsse.common.sci.netcdf_io import read_netcdf
 
 @fixture
 def proj():
-    proj_spec = '+proj=lcc +lat_0=25.0 +lon_0=-95.0 +lat_1=25.0 +a=6371200'
-    grid_spec = '+dx=2539.703 +dy=2539.703 +w=2345 +h=1597 +lat_ll=19.229 +lon_ll=-126.2766'
+    proj_spec = "+proj=lcc +lat_0=25.0 +lon_0=-95.0 +lat_1=25.0 +a=6371200"
+    grid_spec = "+dx=2539.703 +dy=2539.703 +w=2345 +h=1597 +lat_ll=19.229 +lon_ll=-126.2766"
     return GridProj.from_proj_grid_spec(proj_spec, grid_spec)
 
 
 def test_geo_image_without_data_grid(proj):
     fill_color = (255, 0, 0)
     geo_image = GeoImage.from_proj(proj, fill_color)
-    values, _, counts = numpy.unique(geo_image.rgb_array,
-                                     return_inverse=True,
-                                     return_counts=True)
+    values, _, counts = numpy.unique(geo_image.rgb_array, return_inverse=True, return_counts=True)
     # the only value in the grid should be 0 and 255, where there should be twice as many
     # 0 as 255 and the total count should be 11234895 (proj width*height)
     numpy.testing.assert_array_equal(values, [0, 255])
@@ -40,14 +39,12 @@ def test_geo_image_without_data_grid(proj):
 
 
 def test_geo_image_from_data_grid(proj):
-    data = numpy.array([[0, 1, 2, 3],
-                        [4, 5, 6, 7],
-                        [8, 9, 10, 11]])
+    data = numpy.array([[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]])
 
     geo_image = GeoImage.from_data_grid(proj, data)
-    values, indices, counts = numpy.unique(geo_image.rgb_array,
-                                           return_inverse=True,
-                                           return_counts=True)
+    values, indices, counts = numpy.unique(
+        geo_image.rgb_array, return_inverse=True, return_counts=True
+    )
 
     # every value comes in groups of three since the colors are on a grey scale (one each for rgb)
     expected_values = [0, 23, 46, 69, 92, 115, 139, 162, 185, 208, 231, 255]
@@ -58,15 +55,13 @@ def test_geo_image_from_data_grid(proj):
 
 
 def test_geo_image_from_data_grid_with_scale(proj):
-    data = numpy.array([[0, 1, 2, 3],
-                        [4, 5, 6, 7],
-                        [8, 9, 10, 11]])
+    data = numpy.array([[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]])
 
     scale = 5
     geo_image = GeoImage.from_data_grid(proj, data, scale=scale)
-    values, indices, counts = numpy.unique(geo_image.rgb_array,
-                                           return_inverse=True,
-                                           return_counts=True)
+    values, indices, counts = numpy.unique(
+        geo_image.rgb_array, return_inverse=True, return_counts=True
+    )
 
     expected_values = [0, 23, 46, 69, 92, 115, 139, 162, 185, 208, 231, 255]
     expected_indices = numpy.repeat(numpy.repeat(data, [scale, scale, scale], axis=0), scale * 3)
@@ -83,19 +78,89 @@ def test_set_pixel(proj):
     i_j = (1.9, 4.9)
     geo_image.set_pixel(*i_j, (100, 100, 100), geo=False)
 
-    values, indices, counts = numpy.unique(geo_image.rgb_array,
-                                           return_inverse=True,
-                                           return_counts=True)
+    values, indices, counts = numpy.unique(
+        geo_image.rgb_array, return_inverse=True, return_counts=True
+    )
     # values will be 100 (for set pixel) and 0 everywhere else
     numpy.testing.assert_array_equal(values, [0, 100])
     numpy.testing.assert_array_equal(counts, [3675, 75])
-    expected_indices = [810, 811, 812, 813, 814, 815, 816, 817, 818, 819, 820,
-                        821, 822, 823, 824, 960, 961, 962, 963, 964, 965, 966,
-                        967, 968, 969, 970, 971, 972, 973, 974, 1110, 1111, 1112,
-                        1113, 1114, 1115, 1116, 1117, 1118, 1119, 1120, 1121, 1122, 1123,
-                        1124, 1260, 1261, 1262, 1263, 1264, 1265, 1266, 1267, 1268, 1269,
-                        1270, 1271, 1272, 1273, 1274, 1410, 1411, 1412, 1413, 1414, 1415,
-                        1416, 1417, 1418, 1419, 1420, 1421, 1422, 1423, 1424]
+    expected_indices = [
+        810,
+        811,
+        812,
+        813,
+        814,
+        815,
+        816,
+        817,
+        818,
+        819,
+        820,
+        821,
+        822,
+        823,
+        824,
+        960,
+        961,
+        962,
+        963,
+        964,
+        965,
+        966,
+        967,
+        968,
+        969,
+        970,
+        971,
+        972,
+        973,
+        974,
+        1110,
+        1111,
+        1112,
+        1113,
+        1114,
+        1115,
+        1116,
+        1117,
+        1118,
+        1119,
+        1120,
+        1121,
+        1122,
+        1123,
+        1124,
+        1260,
+        1261,
+        1262,
+        1263,
+        1264,
+        1265,
+        1266,
+        1267,
+        1268,
+        1269,
+        1270,
+        1271,
+        1272,
+        1273,
+        1274,
+        1410,
+        1411,
+        1412,
+        1413,
+        1414,
+        1415,
+        1416,
+        1417,
+        1418,
+        1419,
+        1420,
+        1421,
+        1422,
+        1423,
+        1424,
+    ]
     numpy.testing.assert_array_equal(numpy.where(indices == 1)[0], expected_indices)
 
 
@@ -107,18 +172,63 @@ def test_outline_pixel(proj):
     i_j = (1.1, 2.1)
     geo_image.outline_pixel(*i_j, (100, 100, 100), geo=False)
 
-    values, indices, counts = numpy.unique(geo_image.rgb_array,
-                                           return_inverse=True,
-                                           return_counts=True)
+    values, indices, counts = numpy.unique(
+        geo_image.rgb_array, return_inverse=True, return_counts=True
+    )
 
     # values will be 100 (for outlined pixel) and 0 everywhere else
     numpy.testing.assert_array_equal(values, [0, 100])
     numpy.testing.assert_array_equal(counts, [3702, 48])
-    expected_indices = [780, 781, 782, 783, 784, 785, 786, 787, 788, 789, 790,
-                        791, 792, 793, 794, 930, 931, 932, 942, 943, 944, 1080,
-                        1081, 1082, 1092, 1093, 1094, 1230, 1231, 1232, 1242, 1243, 1244,
-                        1380, 1381, 1382, 1383, 1384, 1385, 1386, 1387, 1388, 1389, 1390,
-                        1391, 1392, 1393, 1394]
+    expected_indices = [
+        780,
+        781,
+        782,
+        783,
+        784,
+        785,
+        786,
+        787,
+        788,
+        789,
+        790,
+        791,
+        792,
+        793,
+        794,
+        930,
+        931,
+        932,
+        942,
+        943,
+        944,
+        1080,
+        1081,
+        1082,
+        1092,
+        1093,
+        1094,
+        1230,
+        1231,
+        1232,
+        1242,
+        1243,
+        1244,
+        1380,
+        1381,
+        1382,
+        1383,
+        1384,
+        1385,
+        1386,
+        1387,
+        1388,
+        1389,
+        1390,
+        1391,
+        1392,
+        1393,
+        1394,
+    ]
     numpy.testing.assert_array_equal(numpy.where(indices == 1)[0], expected_indices)
 
 
@@ -130,9 +240,9 @@ def test_draw_point(proj):
     i_j = (1.1, 2.1)
     geo_image.draw_point(*i_j, (100, 0, 0), geo=False)
 
-    values, indices, counts = numpy.unique(geo_image.rgb_array,
-                                           return_inverse=True,
-                                           return_counts=True)
+    values, indices, counts = numpy.unique(
+        geo_image.rgb_array, return_inverse=True, return_counts=True
+    )
 
     # values will be 0 and 100 (for single point) and 0 everywhere else
     numpy.testing.assert_array_equal(values, [0, 100])
@@ -151,31 +261,156 @@ def test_draw_line_seg(proj):
 
     geo_image.draw_line_seg(*i_j_1, *i_j_2, (100, 0, 0), geo=False)
 
-    values, indices, counts = numpy.unique(geo_image.rgb_array,
-                                           return_inverse=True,
-                                           return_counts=True)
+    values, indices, counts = numpy.unique(
+        geo_image.rgb_array, return_inverse=True, return_counts=True
+    )
 
     # values will be 0 or 100 (for line seg) and 0 everywhere else
     numpy.testing.assert_array_equal(values, [0, 100])
     numpy.testing.assert_array_equal(counts, [374859, 141])
-    expected_indices = [82815, 82818, 84321, 84324, 84327, 84330, 85833, 85836,
-                        85839, 87342, 87345, 87348, 87351, 88854, 88857, 88860,
-                        90363, 90366, 90369, 90372, 91875, 91878, 91881, 93384,
-                        93387, 93390, 93393, 94896, 94899, 94902, 96405, 96408,
-                        96411, 96414, 97917, 97920, 97923, 99426, 99429, 99432,
-                        99435, 100938, 100941, 100944, 102447, 102450, 102453, 102456,
-                        103959, 103962, 103965, 105468, 105471, 105474, 105477, 106980,
-                        106983, 106986, 108489, 108492, 108495, 108498, 110001, 110004,
-                        110007, 111510, 111513, 111516, 111519, 113022, 113025, 113028,
-                        114531, 114534, 114537, 114540, 116043, 116046, 116049, 117552,
-                        117555, 117558, 117561, 119064, 119067, 119070, 120573, 120576,
-                        120579, 120582, 122085, 122088, 122091, 123594, 123597, 123600,
-                        123603, 125106, 125109, 125112, 126615, 126618, 126621, 126624,
-                        128127, 128130, 128133, 129636, 129639, 129642, 129645, 131148,
-                        131151, 131154, 132657, 132660, 132663, 132666, 134169, 134172,
-                        134175, 135678, 135681, 135684, 135687, 137190, 137193, 137196,
-                        138699, 138702, 138705, 138708, 140211, 140214, 140217, 141720,
-                        141723, 141726, 141729, 143232, 143235]
+    expected_indices = [
+        82815,
+        82818,
+        84321,
+        84324,
+        84327,
+        84330,
+        85833,
+        85836,
+        85839,
+        87342,
+        87345,
+        87348,
+        87351,
+        88854,
+        88857,
+        88860,
+        90363,
+        90366,
+        90369,
+        90372,
+        91875,
+        91878,
+        91881,
+        93384,
+        93387,
+        93390,
+        93393,
+        94896,
+        94899,
+        94902,
+        96405,
+        96408,
+        96411,
+        96414,
+        97917,
+        97920,
+        97923,
+        99426,
+        99429,
+        99432,
+        99435,
+        100938,
+        100941,
+        100944,
+        102447,
+        102450,
+        102453,
+        102456,
+        103959,
+        103962,
+        103965,
+        105468,
+        105471,
+        105474,
+        105477,
+        106980,
+        106983,
+        106986,
+        108489,
+        108492,
+        108495,
+        108498,
+        110001,
+        110004,
+        110007,
+        111510,
+        111513,
+        111516,
+        111519,
+        113022,
+        113025,
+        113028,
+        114531,
+        114534,
+        114537,
+        114540,
+        116043,
+        116046,
+        116049,
+        117552,
+        117555,
+        117558,
+        117561,
+        119064,
+        119067,
+        119070,
+        120573,
+        120576,
+        120579,
+        120582,
+        122085,
+        122088,
+        122091,
+        123594,
+        123597,
+        123600,
+        123603,
+        125106,
+        125109,
+        125112,
+        126615,
+        126618,
+        126621,
+        126624,
+        128127,
+        128130,
+        128133,
+        129636,
+        129639,
+        129642,
+        129645,
+        131148,
+        131151,
+        131154,
+        132657,
+        132660,
+        132663,
+        132666,
+        134169,
+        134172,
+        134175,
+        135678,
+        135681,
+        135684,
+        135687,
+        137190,
+        137193,
+        137196,
+        138699,
+        138702,
+        138705,
+        138708,
+        140211,
+        140214,
+        140217,
+        141720,
+        141723,
+        141726,
+        141729,
+        143232,
+        143235,
+    ]
     numpy.testing.assert_array_equal(numpy.where(indices == 1)[0], expected_indices)
 
 
@@ -185,13 +420,11 @@ def test_draw_polygon(proj):
     data = numpy.zeros((height, width))
     geo_image = GeoImage.from_data_grid(proj, data, scale=scale)
 
-    geo_image.draw_shape('POLYGON((1.1 1.1, 1.5 1.9, 1.9 1.1, 1.1 1.1))',
-                         (0, 100, 0),
-                         geo=False)
+    geo_image.draw_shape("POLYGON((1.1 1.1, 1.5 1.9, 1.9 1.1, 1.1 1.1))", (0, 100, 0), geo=False)
 
-    values, indices, counts = numpy.unique(geo_image.rgb_array,
-                                           return_inverse=True,
-                                           return_counts=True)
+    values, indices, counts = numpy.unique(
+        geo_image.rgb_array, return_inverse=True, return_counts=True
+    )
 
     # values will be 0 or 100 (for polygon) and 0 everywhere else
     numpy.testing.assert_array_equal(values, [0, 100])
@@ -206,19 +439,37 @@ def test_draw_multi_polygon(proj):
     data = numpy.zeros((height, width))
     geo_image = GeoImage.from_data_grid(proj, data, scale=scale)
 
-    multi_poly = ('MULTIPOLYGON (((1.1 1.1, 1.1 1.9, 1.9 1.9, 1.9 1.1, 1.1 1.1)),'
-                  '((2.1 2.1, 2.5 2.9, 2.9 2.1, 2.1 2.1)))')
+    multi_poly = (
+        "MULTIPOLYGON (((1.1 1.1, 1.1 1.9, 1.9 1.9, 1.9 1.1, 1.1 1.1)),"
+        "((2.1 2.1, 2.5 2.9, 2.9 2.1, 2.1 2.1)))"
+    )
     geo_image.draw_shape(multi_poly, (0, 100, 0), geo=False)
 
-    values, indices, counts = numpy.unique(geo_image.rgb_array,
-                                           return_inverse=True,
-                                           return_counts=True)
+    values, indices, counts = numpy.unique(
+        geo_image.rgb_array, return_inverse=True, return_counts=True
+    )
 
     # values will be 0 or 100 (for polygon) and 0 everywhere else
     numpy.testing.assert_array_equal(values, [0, 100])
     numpy.testing.assert_array_equal(counts, [416, 16])
-    expected_indices = [118, 121, 124, 154, 157, 160, 190, 193,
-                        196, 235, 238, 271, 274, 277, 307, 310]
+    expected_indices = [
+        118,
+        121,
+        124,
+        154,
+        157,
+        160,
+        190,
+        193,
+        196,
+        235,
+        238,
+        271,
+        274,
+        277,
+        307,
+        310,
+    ]
     numpy.testing.assert_array_equal(numpy.where(indices == 1)[0], expected_indices)
 
 
@@ -230,14 +481,16 @@ def test_draw_geo_polygon(proj: GridProj):
     lon_lat_1 = proj.map_pixel_to_geo(1.3, 1.9)
     lon_lat_2 = proj.map_pixel_to_geo(3.5, 2.7)
     lon_lat_3 = proj.map_pixel_to_geo(3.0, 1.5)
-    poly_wkt = (f'POLYGON(({lon_lat_1[0]} {lon_lat_1[1]}, {lon_lat_2[0]} {lon_lat_2[1]}, '
-                f'{lon_lat_3[0]} {lon_lat_3[1]}, {lon_lat_1[0]} {lon_lat_1[1]}))')
+    poly_wkt = (
+        f"POLYGON(({lon_lat_1[0]} {lon_lat_1[1]}, {lon_lat_2[0]} {lon_lat_2[1]}, "
+        f"{lon_lat_3[0]} {lon_lat_3[1]}, {lon_lat_1[0]} {lon_lat_1[1]}))"
+    )
 
     geo_image.draw_shape(poly_wkt, (0, 0, 100))
 
-    values, indices, counts = numpy.unique(geo_image.rgb_array,
-                                           return_inverse=True,
-                                           return_counts=True)
+    values, indices, counts = numpy.unique(
+        geo_image.rgb_array, return_inverse=True, return_counts=True
+    )
 
     # values will be 0 or 100 (for polygon) and 0 everywhere else
     numpy.testing.assert_array_equal(values, [0, 100])
@@ -246,16 +499,116 @@ def test_draw_geo_polygon(proj: GridProj):
     # the "equality" workarounds below are needed due to counts and indices arrays having
     # different results when run with pytest locally vs. in GitHub Actions runner
     assert counts.tolist() == approx([7378, 122], rel=0.10)  # counts can be up to 10% off
-    expected_indices = [2006, 2156, 2306, 2309, 2456, 2459, 2606, 2609, 2753, 2756, 2759,
-                        2762, 2903, 2906, 2909, 2912, 3053, 3056, 3059, 3062, 3203, 3206,
-                        3209, 3212, 3215, 3353, 3356, 3359, 3362, 3365, 3500, 3503, 3506,
-                        3509, 3512, 3515, 3650, 3653, 3656, 3659, 3662, 3665, 3668, 3800,
-                        3803, 3806, 3809, 3812, 3815, 3818, 3950, 3953, 3956, 3959, 3962,
-                        3965, 3968, 3971, 4100, 4103, 4106, 4109, 4112, 4115, 4118, 4121,
-                        4250, 4253, 4256, 4259, 4262, 4265, 4268, 4271, 4397, 4400, 4403,
-                        4406, 4409, 4412, 4415, 4418, 4421, 4424, 4553, 4556, 4559, 4562,
-                        4565, 4568, 4571, 4574, 4709, 4712, 4715, 4718, 4721, 4724, 4865,
-                        4868, 4871, 4874, 4877, 5021, 5024, 5027, 5177, 5330]
+    expected_indices = [
+        2006,
+        2156,
+        2306,
+        2309,
+        2456,
+        2459,
+        2606,
+        2609,
+        2753,
+        2756,
+        2759,
+        2762,
+        2903,
+        2906,
+        2909,
+        2912,
+        3053,
+        3056,
+        3059,
+        3062,
+        3203,
+        3206,
+        3209,
+        3212,
+        3215,
+        3353,
+        3356,
+        3359,
+        3362,
+        3365,
+        3500,
+        3503,
+        3506,
+        3509,
+        3512,
+        3515,
+        3650,
+        3653,
+        3656,
+        3659,
+        3662,
+        3665,
+        3668,
+        3800,
+        3803,
+        3806,
+        3809,
+        3812,
+        3815,
+        3818,
+        3950,
+        3953,
+        3956,
+        3959,
+        3962,
+        3965,
+        3968,
+        3971,
+        4100,
+        4103,
+        4106,
+        4109,
+        4112,
+        4115,
+        4118,
+        4121,
+        4250,
+        4253,
+        4256,
+        4259,
+        4262,
+        4265,
+        4268,
+        4271,
+        4397,
+        4400,
+        4403,
+        4406,
+        4409,
+        4412,
+        4415,
+        4418,
+        4421,
+        4424,
+        4553,
+        4556,
+        4559,
+        4562,
+        4565,
+        4568,
+        4571,
+        4574,
+        4709,
+        4712,
+        4715,
+        4718,
+        4721,
+        4724,
+        4865,
+        4868,
+        4871,
+        4874,
+        4877,
+        5021,
+        5024,
+        5027,
+        5177,
+        5330,
+    ]
 
     # assert actual_indices == expected_indices
 
@@ -271,75 +624,92 @@ def test_set_outline_pixel_for_shape(proj):
     data = numpy.zeros((height, width))
     geo_image = GeoImage.from_data_grid(proj, data, scale=scale)
 
-    geo_image.set_pixel_for_shape('LINESTRING(1.5 7.5, 3.25 8.75)', (1, 100, 100), geo=False)
-    geo_image.outline_pixel_for_shape('POINT(2.3 4)', (2, 100, 100), geo=False)
+    geo_image.set_pixel_for_shape("LINESTRING(1.5 7.5, 3.25 8.75)", (1, 100, 100), geo=False)
+    geo_image.outline_pixel_for_shape("POINT(2.3 4)", (2, 100, 100), geo=False)
 
-    values, indices, counts = numpy.unique(geo_image.rgb_array,
-                                           return_inverse=True,
-                                           return_counts=True)
+    values, indices, counts = numpy.unique(
+        geo_image.rgb_array, return_inverse=True, return_counts=True
+    )
 
     numpy.testing.assert_array_equal(values, [0, 1, 2, 100])
 
     numpy.testing.assert_array_equal(counts, [1245, 27, 8, 70])
-    expected_indices = [333, 336, 339, 423, 426, 429, 513, 516, 519, 612, 615,
-                        618, 702, 705, 708, 792, 795, 798, 882, 885, 888, 972,
-                        975, 978, 1062, 1065, 1068]
+    expected_indices = [
+        333,
+        336,
+        339,
+        423,
+        426,
+        429,
+        513,
+        516,
+        519,
+        612,
+        615,
+        618,
+        702,
+        705,
+        708,
+        792,
+        795,
+        798,
+        882,
+        885,
+        888,
+        972,
+        975,
+        978,
+        1062,
+        1065,
+        1068,
+    ]
     numpy.testing.assert_array_equal(numpy.where(indices == 1)[0], expected_indices)
     expected_indices = [576, 579, 582, 666, 672, 756, 759, 762]
     numpy.testing.assert_array_equal(numpy.where(indices == 2)[0], expected_indices)
 
 
 def test_normalize():
-    data_array = numpy.array([[0, 1, 2],
-                              [3, 4, 5]])
+    data_array = numpy.array([[0, 1, 2], [3, 4, 5]])
     norm_array = normalize(data_array)
 
-    numpy.testing.assert_allclose(norm_array, [[0.0, 0.2, 0.4],
-                                               [0.6, 0.8, 1.0]], atol=0.00001)
+    numpy.testing.assert_allclose(norm_array, [[0.0, 0.2, 0.4], [0.6, 0.8, 1.0]], atol=0.00001)
 
 
 def test_normalize_with_excludes():
-    data_array = numpy.array([[0, 1, 2],
-                              [3, 4, 5]])
+    data_array = numpy.array([[0, 1, 2], [3, 4, 5]])
     norm_array = normalize(data_array, min_value=1, max_value=4, missing_value=3)
 
-    numpy.testing.assert_allclose(norm_array, [[-1.0, 0.0, 0.3333333],
-                                               [numpy.nan, 1.0, 2.0]], atol=0.00001)
-    numpy.testing.assert_array_equal(norm_array.mask, [[True, False, False],
-                                                       [True, False, True]])
+    numpy.testing.assert_allclose(
+        norm_array, [[-1.0, 0.0, 0.3333333], [numpy.nan, 1.0, 2.0]], atol=0.00001
+    )
+    numpy.testing.assert_array_equal(norm_array.mask, [[True, False, False], [True, False, True]])
 
 
 def test_scale_to_color_palette():
-    norm_array = numpy.array([[0.0, 0.2, 0.4],
-                              [0.6, 0.8, 1.0]])
+    norm_array = numpy.array([[0.0, 0.2, 0.4], [0.6, 0.8, 1.0]])
     index_array = scale_to_color_palette(norm_array, 256)
 
-    numpy.testing.assert_array_equal(index_array, [[0, 51, 102],
-                                                   [153, 204, 255]])
+    numpy.testing.assert_array_equal(index_array, [[0, 51, 102], [153, 204, 255]])
 
 
 def test_scale_to_color_palette_force_excludes():
-    norm_array = numpy.array([[-1.0, 0.0, 0.3333333],
-                              [numpy.nan, 1.0, 2.0]])
+    norm_array = numpy.array([[-1.0, 0.0, 0.3333333], [numpy.nan, 1.0, 2.0]])
     index_array = scale_to_color_palette(norm_array, 256)
 
-    numpy.testing.assert_array_equal(index_array, [[0, 0, 84],
-                                                   [0, 255, 255]])
+    numpy.testing.assert_array_equal(index_array, [[0, 0, 84], [0, 255, 255]])
 
 
 def test_scale_to_color_palette_with_excludes():
-    norm_array = numpy.array([[-1.0, 0.0, 0.3333333],
-                              [numpy.nan, 1.0, 2.0]])
+    norm_array = numpy.array([[-1.0, 0.0, 0.3333333], [numpy.nan, 1.0, 2.0]])
     index_array = scale_to_color_palette(norm_array, 256, True, True, True)
 
-    numpy.testing.assert_array_equal(index_array, [[256, 0, 84],
-                                                   [258, 255, 257]])
+    numpy.testing.assert_array_equal(index_array, [[256, 0, 84], [258, 255, 257]])
 
 
 def test_draw_state(proj):
     data = numpy.zeros((proj.width, proj.height))
     geo_image = GeoImage.from_data_grid(proj, data)
-    geo_image.draw_state('Rhode Island', color=(255, 0, 0))
+    geo_image.draw_state("Rhode Island", color=(255, 0, 0))
 
     values, counts = numpy.unique(geo_image.rgb_array, return_counts=True)
     numpy.testing.assert_array_equal(values, [0, 255])
@@ -349,7 +719,7 @@ def test_draw_state(proj):
 def test_add_one_state(proj):
     data = numpy.zeros((proj.width, proj.height))
     geo_image = GeoImage.from_data_grid(proj, data)
-    geo_image.draw_state_boundary('Florida', color=(255, 0, 0))
+    geo_image.draw_state_boundary("Florida", color=(255, 0, 0))
 
     # confirm that at least three of the pixel along the state boundary are colored red
     numpy.testing.assert_array_equal(geo_image.rgb_array[1665, 320], [255, 0, 0])
@@ -360,7 +730,7 @@ def test_add_one_state(proj):
 def test_add_list_of_states(proj):
     data = numpy.zeros((proj.width, proj.height))
     geo_image = GeoImage.from_data_grid(proj, data)
-    geo_image.draw_state_boundary(['Nevada', 'Iowa', 'Delaware'], color=(255, 0, 0))
+    geo_image.draw_state_boundary(["Nevada", "Iowa", "Delaware"], color=(255, 0, 0))
 
     # confirm that at least three of the pixel along state boundaries are colored red
     numpy.testing.assert_array_equal(geo_image.rgb_array[609, 683], [255, 0, 0])
@@ -372,15 +742,16 @@ def test_color_palette():
     # get grey scale color palette (with excludes given default arg)
     color_palette = ColorPalette.grey()
     # length of the lookup table should be 256 (0->255) plus 3 extra for the excludes
-    assert len(color_palette.lut) == 256+3
+    assert len(color_palette.lut) == 256 + 3
     # check that each rgb value matches it's position
     for idx, (red, green, blue) in enumerate(color_palette.lut[:256]):
         assert idx == red == green == blue
 
 
 def test_color_palette_with_anchor():
-    color_palette = ColorPalette.linear([(0, 0, 0), (100, 100, 100), (255, 255, 255)],
-                                        [0, 100, 255])
+    color_palette = ColorPalette.linear(
+        [(0, 0, 0), (100, 100, 100), (255, 255, 255)], [0, 100, 255]
+    )
     # this color palette will not have exclude
     assert len(color_palette.lut) == 256
     # without the anchors the value would not match position
@@ -389,13 +760,17 @@ def test_color_palette_with_anchor():
 
 
 def test_add_all_states(proj):
-    filename = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'resources',
-                            'nbm_temp-202211111100-202211121300.nc')
+    filename = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        "..",
+        "resources",
+        "nbm_temp-202211111100-202211121300.nc",
+    )
     attrs, data = read_netcdf(filename)
-    if attrs['data_order'] == 'latitude,longitude':
+    if attrs["data_order"] == "latitude,longitude":
         data = numpy.transpose(data)
     geo_image = GeoImage.from_data_grid(proj, data)
-    geo_image.draw_state_boundary('All', color=(255, 0, 0))
+    geo_image.draw_state_boundary("All", color=(255, 0, 0))
 
     # confirm that at least three of the pixel along state boundaries are colored red
     numpy.testing.assert_array_equal(geo_image.rgb_array[1707, 861], [255, 0, 0])

--- a/python/idsse_common/test/sci/test_grid_proj.py
+++ b/python/idsse_common/test/sci/test_grid_proj.py
@@ -1,4 +1,5 @@
 """Test suite for grid_proj.py"""
+
 # ----------------------------------------------------------------------------------
 # Created on Wed Aug 2 2023
 #
@@ -23,32 +24,28 @@ from idsse.common.utils import round_, RoundingMethod
 
 
 # example data
-EXAMPLE_PROJ_SPEC = '+proj=lcc +lat_0=25.0 +lon_0=-95.0 +lat_1=25.0 +a=6371200'
-EXAMPLE_GRID_SPEC = '+dx=2539.703 +dy=2539.703 +w=2345 +h=1597 +lat_ll=19.229 +lon_ll=-126.2766'
+EXAMPLE_PROJ_SPEC = "+proj=lcc +lat_0=25.0 +lon_0=-95.0 +lat_1=25.0 +a=6371200"
+EXAMPLE_GRID_SPEC = "+dx=2539.703 +dy=2539.703 +w=2345 +h=1597 +lat_ll=19.229 +lon_ll=-126.2766"
 
 PROJ_SPEC_WITH_OFFSET = (
-    '+proj=lcc +lat_0=25.0 +lon_0=-95.0 +lat_1=25.0 '
-    '+x_0=3275807.350733357 +y_0=260554.63043505285 +a=6371200'
+    "+proj=lcc +lat_0=25.0 +lon_0=-95.0 +lat_1=25.0 "
+    "+x_0=3275807.350733357 +y_0=260554.63043505285 +a=6371200"
 )
-GRID_SPEC_WITHOUT_LOWER_LEFT = '+dx=2539.703 +dy=2539.703 +w=2345 +h=1597'
+GRID_SPEC_WITHOUT_LOWER_LEFT = "+dx=2539.703 +dy=2539.703 +w=2345 +h=1597"
 
 WIDTH = 2345
 HEIGHT = 1597
 
-EXAMPLE_PIXELS: Sequence[tuple[int, int]] = [
-    (0, 0),
-    (0, 1),
-    (2000, 1500)
-]
+EXAMPLE_PIXELS: Sequence[tuple[int, int]] = [(0, 0), (0, 1), (2000, 1500)]
 EXAMPLE_LON_LAT = [
     (-126.2766, 19.229),
     (-126.28210431967231, 19.25112362717893),
-    (-71.02234126905036, 54.014077268729)
+    (-71.02234126905036, 54.014077268729),
 ]
 EXAMPLE_CRS = [
     (-3271151.6058371724, -263793.7334645616),
     (-3271151.6058371724, -261254.03046456157),
-    (1808254.3941628276, 3545760.7665354386)
+    (1808254.3941628276, 3545760.7665354386),
 ]
 
 
@@ -74,13 +71,14 @@ def test_from_proj_grid_spec(grid_proj: GridProj):
     assert grid_proj._dy == grid_proj._dx
 
     t = grid_proj._trans
-    assert t.source_crs is not None and t.source_crs.type_name == 'Geographic 2D CRS'
-    assert t.target_crs is not None and t.target_crs.type_name == 'Projected CRS'
+    assert t.source_crs is not None and t.source_crs.type_name == "Geographic 2D CRS"
+    assert t.target_crs is not None and t.target_crs.type_name == "Projected CRS"
 
 
 def test_from_proj_grid_spec_with_offset():
-    proj_with_offset = GridProj.from_proj_grid_spec(PROJ_SPEC_WITH_OFFSET,
-                                                    GRID_SPEC_WITHOUT_LOWER_LEFT)
+    proj_with_offset = GridProj.from_proj_grid_spec(
+        PROJ_SPEC_WITH_OFFSET, GRID_SPEC_WITHOUT_LOWER_LEFT
+    )
 
     proj_xy = proj_with_offset.map_pixel_to_geo(*EXAMPLE_PIXELS[0])
     assert proj_xy == approx_tuple((-126.32657866, 19.247681536))
@@ -121,19 +119,13 @@ def test_flip_both_lr_ud(grid_proj: GridProj):
 # transformation methods testing
 def test_map_crs_to_pixel_round(grid_proj: GridProj):
     for index, crs_xy in enumerate(EXAMPLE_CRS):
-        pixel_xy = grid_proj.map_crs_to_pixel(
-            *crs_xy,
-            rounding=RoundingMethod.ROUND
-        )
+        pixel_xy = grid_proj.map_crs_to_pixel(*crs_xy, rounding=RoundingMethod.ROUND)
         assert pixel_xy == EXAMPLE_PIXELS[index]
 
 
 def test_map_crs_to_pixel_floor(grid_proj: GridProj):
     for index, crs_xy in enumerate(EXAMPLE_CRS):
-        i, j = grid_proj.map_crs_to_pixel(
-            *crs_xy,
-            rounding=RoundingMethod.FLOOR
-        )
+        i, j = grid_proj.map_crs_to_pixel(*crs_xy, rounding=RoundingMethod.FLOOR)
         # due to math imprecision internal to pyproj.transform(), some test results are a bit
         # unpredictable. E.g. returns 0.999994, which floors to 0, when expected pixel value is 1
         assert (approx(i, abs=1), approx(j, abs=1)) == EXAMPLE_PIXELS[index]
@@ -177,7 +169,8 @@ def test_crs_to_pixel_floor(grid_proj: GridProj):
 
         floor_ij = grid_proj.map_crs_to_pixel(*geo, rounding=RoundingMethod.FLOOR)
         assert (
-            round_(i, rounding=RoundingMethod.FLOOR), round_(j, rounding=RoundingMethod.FLOOR)
+            round_(i, rounding=RoundingMethod.FLOOR),
+            round_(j, rounding=RoundingMethod.FLOOR),
         ) == floor_ij
 
 
@@ -188,10 +181,10 @@ def test_crs_to_pixel_round(grid_proj: GridProj):
 
 
 def test_crs_to_pixel_round_str(grid_proj: GridProj):
-    i, j = grid_proj.map_crs_to_pixel(*EXAMPLE_CRS[0], rounding='round')
+    i, j = grid_proj.map_crs_to_pixel(*EXAMPLE_CRS[0], rounding="round")
     assert (i, j) == EXAMPLE_PIXELS[0]
 
-    i, j = grid_proj.map_crs_to_pixel(*EXAMPLE_CRS[1], rounding='ROUND')
+    i, j = grid_proj.map_crs_to_pixel(*EXAMPLE_CRS[1], rounding="ROUND")
     assert (i, j) == EXAMPLE_PIXELS[1]
 
 
@@ -262,9 +255,9 @@ def test_unbalanced_pixel_or_crs_arrays_fail_to_transform(grid_proj: GridProj):
     with raises(TypeError) as exc:
         bad_pixel = (1.0, [1.0, 2.0, 3.0])
         grid_proj.map_pixel_to_crs(*bad_pixel)
-    assert 'Cannot transpose pixel values' in exc.value.args[0]
+    assert "Cannot transpose pixel values" in exc.value.args[0]
 
     with raises(TypeError) as exc:
         bad_crs = (EXAMPLE_CRS[0], EXAMPLE_CRS[1][1])
         grid_proj.map_crs_to_pixel(*bad_crs, rounding=RoundingMethod.ROUND)
-    assert 'Cannot transpose CRS values' in exc.value.args[0]
+    assert "Cannot transpose CRS values" in exc.value.args[0]

--- a/python/idsse_common/test/sci/test_netcdf_io.py
+++ b/python/idsse_common/test/sci/test_netcdf_io.py
@@ -1,4 +1,5 @@
 """Test suite for netcdf_io.py"""
+
 # --------------------------------------------------------------------------------
 # Created on Mon May 1 2023
 #
@@ -19,27 +20,27 @@ from idsse.common.sci.netcdf_io import read_netcdf, read_netcdf_global_attrs, wr
 
 
 # test data
-EXAMPLE_NETCDF_FILEPATH = f'{os.path.dirname(__file__)}/../resources/gridstore55657865.nc'
+EXAMPLE_NETCDF_FILEPATH = f"{os.path.dirname(__file__)}/../resources/gridstore55657865.nc"
 
 EXAMPLE_ATTRIBUTES = {
-    'product': 'NBM.AWS.GRIB',
-    'field': 'TEMP',
-    'valid_dt': '2022-11-11 17:00:00+00:00',
-    'issue_dt': '2022-11-11 14:00:00+00:00',
-    'task': 'data_task',
-    'region': 'CONUS',
-    'units': 'Fahrenheit',
-    'proj_name': 'NBM',
-    'proj_spec': '+proj=lcc +lat_0=25.0 +lon_0=-95.0 +lat_1=25.0 +a=6371200',
-    'grid_spec': '+dx=2539.703 +dy=2539.703 +w=2345 +h=1597 +lat_ll=19.229 +lon_ll=-126.2766',
-    'data_key': 'NBM.AWS.GRIB:CO:TEMP::Fahrenheit::20221111140000.20221111170000',
-    'data_name': 'Temperature: 2m',
-    'data_loc': 'arn:aws:s3:::noaa-nbm-grib2-pds:',
-    'data_order': 'latitude,longitude'
+    "product": "NBM.AWS.GRIB",
+    "field": "TEMP",
+    "valid_dt": "2022-11-11 17:00:00+00:00",
+    "issue_dt": "2022-11-11 14:00:00+00:00",
+    "task": "data_task",
+    "region": "CONUS",
+    "units": "Fahrenheit",
+    "proj_name": "NBM",
+    "proj_spec": "+proj=lcc +lat_0=25.0 +lon_0=-95.0 +lat_1=25.0 +a=6371200",
+    "grid_spec": "+dx=2539.703 +dy=2539.703 +w=2345 +h=1597 +lat_ll=19.229 +lon_ll=-126.2766",
+    "data_key": "NBM.AWS.GRIB:CO:TEMP::Fahrenheit::20221111140000.20221111170000",
+    "data_name": "Temperature: 2m",
+    "data_loc": "arn:aws:s3:::noaa-nbm-grib2-pds:",
+    "data_order": "latitude,longitude",
 }
 
 EXAMPLE_PROD_KEY = (
-    'product:NBM.AWS.GRIB-field:TEMP-issue:20221111140000-valid:20221112000000-units:Fahrenheit'
+    "product:NBM.AWS.GRIB-field:TEMP-issue:20221111140000-valid:20221112000000-units:Fahrenheit"
 )
 
 
@@ -72,9 +73,9 @@ def test_read_netcdf(example_netcdf_data: tuple[dict[str, any], ndarray]):
 
 @fixture
 def destination_nc_file() -> str:
-    parent_dir = os.path.abspath('./tmp')
-    file = 'test_netcdf_file.nc'
-    filepath = f'{parent_dir}/{file}'
+    parent_dir = os.path.abspath("./tmp")
+    file = "test_netcdf_file.nc"
+    filepath = f"{parent_dir}/{file}"
     # create test file dir if needed
     if not os.path.exists(parent_dir):
         os.mkdir(parent_dir)
@@ -91,13 +92,14 @@ def destination_nc_file() -> str:
         os.rmdir(parent_dir)
 
 
-def test_read_and_write_netcdf(example_netcdf_data: tuple[dict[str, any], ndarray],
-                               destination_nc_file: str):
+def test_read_and_write_netcdf(
+    example_netcdf_data: tuple[dict[str, any], ndarray], destination_nc_file: str
+):
     attrs, grid = example_netcdf_data
 
     # verify write_netcdf functionality
-    attrs['prodKey'] = EXAMPLE_PROD_KEY
-    attrs['prodSource'] = attrs['product']
+    attrs["prodKey"] = EXAMPLE_PROD_KEY
+    attrs["prodSource"] = attrs["product"]
     written_filepath = write_netcdf(attrs, grid, destination_nc_file)
     assert written_filepath == destination_nc_file
     assert os.path.exists(destination_nc_file)
@@ -107,13 +109,14 @@ def test_read_and_write_netcdf(example_netcdf_data: tuple[dict[str, any], ndarra
     assert new_file_grid[123][321] == grid[123][321]
 
 
-def test_read_and_write_netcdf_with_h5nc(example_netcdf_data: tuple[dict[str, any], ndarray],
-                                         destination_nc_file: str):
+def test_read_and_write_netcdf_with_h5nc(
+    example_netcdf_data: tuple[dict[str, any], ndarray], destination_nc_file: str
+):
     attrs, grid = example_netcdf_data
 
     # verify write_netcdf_with_h5nc functionality
-    attrs['prodKey'] = EXAMPLE_PROD_KEY
-    attrs['prodSource'] = attrs['product']
+    attrs["prodKey"] = EXAMPLE_PROD_KEY
+    attrs["prodSource"] = attrs["product"]
     written_filepath = write_netcdf(attrs, grid, destination_nc_file, use_h5_lib=True)
     assert written_filepath == destination_nc_file
 

--- a/python/idsse_common/test/sci/test_vectaster.py
+++ b/python/idsse_common/test/sci/test_vectaster.py
@@ -1,4 +1,5 @@
-'''Test suite for vectaster.py'''
+"""Test suite for vectaster.py"""
+
 # ----------------------------------------------------------------------------------
 # Created on Mon Dec 8 2023
 #
@@ -17,19 +18,21 @@ import numpy
 from pytest import fixture, MonkeyPatch
 
 from idsse.common.sci.grid_proj import GridProj
-from idsse.common.sci.vectaster import (geographic_to_pixel,
-                                        geographic_linestring_to_pixel,
-                                        geographic_point_to_pixel,
-                                        geographic_polygon_to_pixel,
-                                        from_wkt,
-                                        rasterize,
-                                        rasterize_point,
-                                        rasterize_linestring,
-                                        rasterize_polygon)
+from idsse.common.sci.vectaster import (
+    geographic_to_pixel,
+    geographic_linestring_to_pixel,
+    geographic_point_to_pixel,
+    geographic_polygon_to_pixel,
+    from_wkt,
+    rasterize,
+    rasterize_point,
+    rasterize_linestring,
+    rasterize_polygon,
+)
 
 
-EXAMPLE_PROJ_SPEC = '+proj=lcc +lat_0=25.0 +lon_0=-95.0 +lat_1=25.0 +a=6371200'
-EXAMPLE_GRID_SPEC = '+dx=2539.703 +dy=2539.703 +w=2345 +h=1597 +lat_ll=19.229 +lon_ll=-126.2766'
+EXAMPLE_PROJ_SPEC = "+proj=lcc +lat_0=25.0 +lon_0=-95.0 +lat_1=25.0 +a=6371200"
+EXAMPLE_GRID_SPEC = "+dx=2539.703 +dy=2539.703 +w=2345 +h=1597 +lat_ll=19.229 +lon_ll=-126.2766"
 
 
 @fixture
@@ -39,50 +42,56 @@ def grid_proj() -> GridProj:
 
 # test
 def test_geographic_point_to_pixel(grid_proj: GridProj):
-    point = from_wkt('POINT (-105 40)')
-    pixel_point = from_wkt('POINT (940.5282319922111 781.3426922405841)')
+    point = from_wkt("POINT (-105 40)")
+    pixel_point = from_wkt("POINT (940.5282319922111 781.3426922405841)")
     result = geographic_point_to_pixel(point, grid_proj)
 
     assert result == pixel_point
 
 
 def test_geographic_linestring_to_pixel(grid_proj: GridProj):
-    linestring = from_wkt('LINESTRING (-100 30, -110 40, -120 50)')
-    pixel_linestring = from_wkt('LINESTRING (1097.723937434988 326.5786009191758,'
-                                '767.3803599551428 797.3524918062432,'
-                                '509.3960133013222 1309.2825656112072)')
+    linestring = from_wkt("LINESTRING (-100 30, -110 40, -120 50)")
+    pixel_linestring = from_wkt(
+        "LINESTRING (1097.723937434988 326.5786009191758,"
+        "767.3803599551428 797.3524918062432,"
+        "509.3960133013222 1309.2825656112072)"
+    )
     result = geographic_linestring_to_pixel(linestring, grid_proj)
     assert result == pixel_linestring
 
 
 def test_geographic_polygon_to_pixel(grid_proj: GridProj):
-    poly = from_wkt('POLYGON ((-105 40, -110 40, -110 50, -105 50, -105 40), '
-                    '(-107 42, -107 47, -108 47, -108 42, -107 42))')
-    pixel_poly = from_wkt('POLYGON ((940.5282319922111 781.3426922405841,'
-                          '767.3803599551428 797.3524918062432,'
-                          '819.139672193266 1263.254300515678,'
-                          '975.0735971750927 1248.836156907704,'
-                          '940.5282319922111 781.3426922405841),'
-                          '(879.2683115975804 877.9054076290231,'
-                          '899.8846796684276 1110.2160158217966,'
-                          '867.636632346796 1113.1977722126155,'
-                          '845.307298979268 881.0455502058236,'
-                          '879.2683115975804 877.9054076290231))')
+    poly = from_wkt(
+        "POLYGON ((-105 40, -110 40, -110 50, -105 50, -105 40), "
+        "(-107 42, -107 47, -108 47, -108 42, -107 42))"
+    )
+    pixel_poly = from_wkt(
+        "POLYGON ((940.5282319922111 781.3426922405841,"
+        "767.3803599551428 797.3524918062432,"
+        "819.139672193266 1263.254300515678,"
+        "975.0735971750927 1248.836156907704,"
+        "940.5282319922111 781.3426922405841),"
+        "(879.2683115975804 877.9054076290231,"
+        "899.8846796684276 1110.2160158217966,"
+        "867.636632346796 1113.1977722126155,"
+        "845.307298979268 881.0455502058236,"
+        "879.2683115975804 877.9054076290231))"
+    )
     result = geographic_polygon_to_pixel(poly, grid_proj)
     assert result == pixel_poly
 
 
 def test_geographic_to_pixel(monkeypatch: MonkeyPatch, grid_proj: GridProj):
-    point = from_wkt('POINT (-105 40)')
-    line_string = from_wkt('LINESTRING (-105 40, -110 40, -110 50)')
-    polygon = from_wkt('POLYGON ((-105 40, -110 40, -110 50, -105 50, -105 40))')
+    point = from_wkt("POINT (-105 40)")
+    line_string = from_wkt("LINESTRING (-105 40, -110 40, -110 50)")
+    polygon = from_wkt("POLYGON ((-105 40, -110 40, -110 50, -105 50, -105 40))")
 
     point_mock = Mock()
     line_str_mock = Mock()
     polygon_mock = Mock()
-    monkeypatch.setattr('idsse.common.sci.vectaster.geographic_point_to_pixel', point_mock)
-    monkeypatch.setattr('idsse.common.sci.vectaster.geographic_linestring_to_pixel', line_str_mock)
-    monkeypatch.setattr('idsse.common.sci.vectaster.geographic_polygon_to_pixel', polygon_mock)
+    monkeypatch.setattr("idsse.common.sci.vectaster.geographic_point_to_pixel", point_mock)
+    monkeypatch.setattr("idsse.common.sci.vectaster.geographic_linestring_to_pixel", line_str_mock)
+    monkeypatch.setattr("idsse.common.sci.vectaster.geographic_polygon_to_pixel", polygon_mock)
 
     _ = geographic_to_pixel(point, grid_proj)
     point_mock.assert_called_once_with(point, grid_proj, None)
@@ -95,7 +104,7 @@ def test_geographic_to_pixel(monkeypatch: MonkeyPatch, grid_proj: GridProj):
 
 
 def test_rasterize_point(grid_proj: GridProj):
-    point = 'POINT (-100.5 30.5)'
+    point = "POINT (-100.5 30.5)"
     pixels = (numpy.array([1079]), numpy.array([349]))
     result = rasterize_point(point, grid_proj)
     numpy.testing.assert_array_equal(result, pixels)
@@ -109,32 +118,100 @@ def test_rasterize_point_from_coord(grid_proj: GridProj):
 
 
 def test_rasterize_point_without_grid_proj():
-    point = from_wkt('POINT (1001.5 1130.5)')
-    pixels = ((numpy.array([1001]), numpy.array([1130])))
+    point = from_wkt("POINT (1001.5 1130.5)")
+    pixels = (numpy.array([1001]), numpy.array([1130]))
     # default round in floor
     result = rasterize_point(point)
     numpy.testing.assert_array_equal(result, pixels)
 
-    pixels = ((numpy.array([1002]), numpy.array([1131])))
+    pixels = (numpy.array([1002]), numpy.array([1131]))
     # rounding='round' means round half away from zero (both even and odd)
-    result = rasterize_point(point, rounding='round')
+    result = rasterize_point(point, rounding="round")
     numpy.testing.assert_array_equal(result, pixels)
 
 
 def test_rasterize_linestring(grid_proj: GridProj):
-    linestring = 'LINESTRING (-100 30, -100.1 30.1, -100.2 30)'
-    pixels = (numpy.array([1090, 1091, 1092, 1092, 1093, 1094, 1095, 1095, 1096, 1096, 1097]),
-              numpy.array([326, 327, 328, 329, 330, 331, 329, 330, 327, 328, 326]))
+    linestring = "LINESTRING (-100 30, -100.1 30.1, -100.2 30)"
+    pixels = (
+        numpy.array([1090, 1091, 1092, 1092, 1093, 1094, 1095, 1095, 1096, 1096, 1097]),
+        numpy.array([326, 327, 328, 329, 330, 331, 329, 330, 327, 328, 326]),
+    )
     result = rasterize_linestring(linestring, grid_proj)
     numpy.testing.assert_array_equal(result, pixels)
 
 
 def test_rasterize_polygon_as_linestring(grid_proj: GridProj):
-    poly = from_wkt('POLYGON ((0 0, 0 5, 5 5, 5 0, 0 0), (1 1, 3 1, 3 4, 1 4, 1 1))')
-    pixels = (numpy.array([0, 0, 0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 5, 5, 5, 5, 1, 1,
-                           1, 1, 2, 2, 3, 3, 3, 3]),
-              numpy.array([0, 1, 2, 3, 4, 5, 0, 5, 0, 5, 0, 5, 0, 5, 0, 1, 2, 3, 4, 5, 1, 2,
-                           3, 4, 1, 4, 1, 2, 3, 4]))
+    poly = from_wkt("POLYGON ((0 0, 0 5, 5 5, 5 0, 0 0), (1 1, 3 1, 3 4, 1 4, 1 1))")
+    pixels = (
+        numpy.array(
+            [
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                1,
+                1,
+                2,
+                2,
+                3,
+                3,
+                4,
+                4,
+                5,
+                5,
+                5,
+                5,
+                5,
+                5,
+                1,
+                1,
+                1,
+                1,
+                2,
+                2,
+                3,
+                3,
+                3,
+                3,
+            ]
+        ),
+        numpy.array(
+            [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                0,
+                5,
+                0,
+                5,
+                0,
+                5,
+                0,
+                5,
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                1,
+                2,
+                3,
+                4,
+                1,
+                4,
+                1,
+                2,
+                3,
+                4,
+            ]
+        ),
+    )
     result = rasterize_linestring(poly, grid_proj)
     numpy.testing.assert_array_equal(result, pixels)
 
@@ -147,60 +224,266 @@ def test_rasterize_linestring_from_coords(grid_proj: GridProj):
 
 
 def test_rasterize_polygon(grid_proj: GridProj):
-    poly = 'POLYGON ((-105 40, -105.1 40, -105.1 40.1, -105 40.1, -105 40))'
-    pixels = (numpy.array([937, 937, 937, 937, 937, 937, 938, 938, 938, 938, 938, 938, 939,
-                           939, 939, 939, 939, 940, 940, 940, 940, 940]),
-              numpy.array([781, 782, 783, 784, 785, 786, 781, 782, 783, 784, 785, 786, 781,
-                           782, 783, 784, 785, 781, 782, 783, 784, 785]))
+    poly = "POLYGON ((-105 40, -105.1 40, -105.1 40.1, -105 40.1, -105 40))"
+    pixels = (
+        numpy.array(
+            [
+                937,
+                937,
+                937,
+                937,
+                937,
+                937,
+                938,
+                938,
+                938,
+                938,
+                938,
+                938,
+                939,
+                939,
+                939,
+                939,
+                939,
+                940,
+                940,
+                940,
+                940,
+                940,
+            ]
+        ),
+        numpy.array(
+            [
+                781,
+                782,
+                783,
+                784,
+                785,
+                786,
+                781,
+                782,
+                783,
+                784,
+                785,
+                786,
+                781,
+                782,
+                783,
+                784,
+                785,
+                781,
+                782,
+                783,
+                784,
+                785,
+            ]
+        ),
+    )
     result = rasterize_polygon(poly, grid_proj)
     numpy.testing.assert_array_equal(result, pixels)
 
 
 def test_rasterize_polygon_from_coords(grid_proj: GridProj):
     poly = (((-105, 40), (-105.1, 40), (-105.1, 40.1), (-105, 40)),)
-    pixels = (numpy.array([937, 937, 937, 937, 937, 937, 938, 938, 938,
-                           938, 938, 939, 939, 939, 940]),
-              numpy.array([781, 782, 783, 784, 785, 786, 781, 782, 783,
-                           784, 785, 781, 782, 783, 781]))
+    pixels = (
+        numpy.array([937, 937, 937, 937, 937, 937, 938, 938, 938, 938, 938, 939, 939, 939, 940]),
+        numpy.array([781, 782, 783, 784, 785, 786, 781, 782, 783, 784, 785, 781, 782, 783, 781]),
+    )
     result = rasterize_polygon(poly, grid_proj)
     numpy.testing.assert_array_equal(result, pixels)
 
 
 def test_rasterize_polygon_with_hole():
-    poly = from_wkt('POLYGON ((0 0, 0 5, 5 5, 5 0, 0 0), (1 1, 3 1, 3 4, 1 4, 1 1))')
-    pixels = (numpy.array([0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3,
-                           4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5]),
-              numpy.array([0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 4, 5, 0, 1, 2, 3, 4, 5,
-                           0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5]))
+    poly = from_wkt("POLYGON ((0 0, 0 5, 5 5, 5 0, 0 0), (1 1, 3 1, 3 4, 1 4, 1 1))")
+    pixels = (
+        numpy.array(
+            [
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                2,
+                2,
+                2,
+                2,
+                3,
+                3,
+                3,
+                3,
+                3,
+                3,
+                4,
+                4,
+                4,
+                4,
+                4,
+                4,
+                5,
+                5,
+                5,
+                5,
+                5,
+                5,
+            ]
+        ),
+        numpy.array(
+            [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                0,
+                1,
+                4,
+                5,
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+            ]
+        ),
+    )
     result = rasterize_polygon(poly)
     numpy.testing.assert_array_equal(result, pixels)
 
 
 def test_rasterize_multi_polygon():
-    multi_poly = from_wkt('MULTIPOLYGON (((40 40, 39 41, 41 39, 40 40)), '
-                          '((20 35, 19 34, 19 33, 22 33, 35 34, 20 35), '
-                          '(30 20, 28 18, 29 19, 30 20)))')
-    pixels = (numpy.array([39, 40, 41, 19, 19, 20, 20, 20, 21, 21, 21, 22, 22, 22,
-                           23, 23, 23, 24, 24, 24, 25, 25, 25, 26, 26, 26, 27, 27,
-                           27, 28, 28, 29, 30, 31, 32, 33, 34, 35]),
-              numpy.array([41, 40, 39, 33, 34, 33, 34, 35, 33, 34, 35, 33, 34, 35,
-                           33, 34, 35, 33, 34, 35, 33, 34, 35, 33, 34, 35, 33, 34,
-                           35, 33, 34, 34, 34, 34, 34, 34, 34, 34]))
+    multi_poly = from_wkt(
+        "MULTIPOLYGON (((40 40, 39 41, 41 39, 40 40)), "
+        "((20 35, 19 34, 19 33, 22 33, 35 34, 20 35), "
+        "(30 20, 28 18, 29 19, 30 20)))"
+    )
+    pixels = (
+        numpy.array(
+            [
+                39,
+                40,
+                41,
+                19,
+                19,
+                20,
+                20,
+                20,
+                21,
+                21,
+                21,
+                22,
+                22,
+                22,
+                23,
+                23,
+                23,
+                24,
+                24,
+                24,
+                25,
+                25,
+                25,
+                26,
+                26,
+                26,
+                27,
+                27,
+                27,
+                28,
+                28,
+                29,
+                30,
+                31,
+                32,
+                33,
+                34,
+                35,
+            ]
+        ),
+        numpy.array(
+            [
+                41,
+                40,
+                39,
+                33,
+                34,
+                33,
+                34,
+                35,
+                33,
+                34,
+                35,
+                33,
+                34,
+                35,
+                33,
+                34,
+                35,
+                33,
+                34,
+                35,
+                33,
+                34,
+                35,
+                33,
+                34,
+                35,
+                33,
+                34,
+                35,
+                33,
+                34,
+                34,
+                34,
+                34,
+                34,
+                34,
+                34,
+                34,
+            ]
+        ),
+    )
     result = rasterize(multi_poly)
     numpy.testing.assert_array_equal(result, pixels)
 
 
 def test_rasterize(monkeypatch: MonkeyPatch, grid_proj: GridProj):
-    point = from_wkt('POINT (-105 40)')
-    linestring = from_wkt('LINESTRING (-105 40, -110 40, -110 50)')
-    polygon = 'POLYGON ((-105 40, -110 40, -110 50, -105 50, -105 40))'
+    point = from_wkt("POINT (-105 40)")
+    linestring = from_wkt("LINESTRING (-105 40, -110 40, -110 50)")
+    polygon = "POLYGON ((-105 40, -110 40, -110 50, -105 50, -105 40))"
 
     point_mock = Mock()
     linestring_mock = Mock()
     polygon_mock = Mock()
-    monkeypatch.setattr('idsse.common.sci.vectaster.rasterize_point', point_mock)
-    monkeypatch.setattr('idsse.common.sci.vectaster.rasterize_linestring', linestring_mock)
-    monkeypatch.setattr('idsse.common.sci.vectaster.rasterize_polygon', polygon_mock)
+    monkeypatch.setattr("idsse.common.sci.vectaster.rasterize_point", point_mock)
+    monkeypatch.setattr("idsse.common.sci.vectaster.rasterize_linestring", linestring_mock)
+    monkeypatch.setattr("idsse.common.sci.vectaster.rasterize_polygon", polygon_mock)
 
     rasterize(point, grid_proj)
     point_mock.assert_called_once()

--- a/python/idsse_common/test/test_aws_utils.py
+++ b/python/idsse_common/test/test_aws_utils.py
@@ -1,4 +1,5 @@
 """Test suite for aws_utils.py"""
+
 # ----------------------------------------------------------------------------------
 # Created on Wed Jun 21 2023
 #
@@ -25,31 +26,35 @@ from idsse.common.aws_utils import AwsUtils
 EXAMPLE_ISSUE = datetime(1970, 10, 3, 12, tzinfo=UTC)
 EXAMPLE_VALID = datetime(1970, 10, 3, 14, tzinfo=UTC)
 
-EXAMPLE_DIR = 's3://noaa-nbm-grib2-pds/blend.19701003/12/core/'
-EXAMPLE_FILES = ['blend.t12z.core.f002.co.grib2',
-                 'blend.t12z.core.f003.co.grib2',
-                 'blend.t12z.core.f004.co.grib2']
+EXAMPLE_DIR = "s3://noaa-nbm-grib2-pds/blend.19701003/12/core/"
+EXAMPLE_FILES = [
+    "blend.t12z.core.f002.co.grib2",
+    "blend.t12z.core.f003.co.grib2",
+    "blend.t12z.core.f004.co.grib2",
+]
 
 
 # fixtures
 @fixture
 def aws_utils() -> AwsUtils:
-    EXAMPLE_BASE_DIR = 's3://noaa-nbm-grib2-pds/'
-    EXAMPLE_SUB_DIR = ('blend.{issue.year:04d}{issue.month:02d}{issue.day:02d}/'
-                       '{issue.hour:02d}/core/')
-    EXAMPLE_FILE_BASE = 'blend.t{issue.hour:02d}z.core.f{lead.hour:03d}'
-    EXAMPLE_FILE_EXT = '.co.grib2'
+    EXAMPLE_BASE_DIR = "s3://noaa-nbm-grib2-pds/"
+    EXAMPLE_SUB_DIR = (
+        "blend.{issue.year:04d}{issue.month:02d}{issue.day:02d}/{issue.hour:02d}/core/"
+    )
+    EXAMPLE_FILE_BASE = "blend.t{issue.hour:02d}z.core.f{lead.hour:03d}"
+    EXAMPLE_FILE_EXT = ".co.grib2"
 
     return AwsUtils(EXAMPLE_BASE_DIR, EXAMPLE_SUB_DIR, EXAMPLE_FILE_BASE, EXAMPLE_FILE_EXT)
 
 
 @fixture
 def aws_utils_with_wild() -> AwsUtils:
-    EXAMPLE_BASE_DIR = 's3://noaa-nbm-grib2-pds/'
-    EXAMPLE_SUB_DIR = ('blend.{issue.year:04d}{issue.month:02d}{issue.day:02d}/'
-                       '{issue.hour:02d}/core/')
-    EXAMPLE_FILE_BASE = 'blend.t{issue.hour:02d}z.core.f?{lead.hour:02d}'
-    EXAMPLE_FILE_EXT = '.co.grib2'
+    EXAMPLE_BASE_DIR = "s3://noaa-nbm-grib2-pds/"
+    EXAMPLE_SUB_DIR = (
+        "blend.{issue.year:04d}{issue.month:02d}{issue.day:02d}/{issue.hour:02d}/core/"
+    )
+    EXAMPLE_FILE_BASE = "blend.t{issue.hour:02d}z.core.f?{lead.hour:02d}"
+    EXAMPLE_FILE_EXT = ".co.grib2"
 
     return AwsUtils(EXAMPLE_BASE_DIR, EXAMPLE_SUB_DIR, EXAMPLE_FILE_BASE, EXAMPLE_FILE_EXT)
 
@@ -57,29 +62,32 @@ def aws_utils_with_wild() -> AwsUtils:
 @fixture
 def mock_exec_cmd(monkeypatch: MonkeyPatch) -> Mock:
     def get_files_for_dir(args: Iterable[str]) -> Sequence[str]:
-        if args[-1].endswith('grib2') or args[-1].endswith('/'):
-            hour = args[-1].split('/')[-3]
+        if args[-1].endswith("grib2") or args[-1].endswith("/"):
+            hour = args[-1].split("/")[-3]
         else:
-            hour = args[-1].split('/')[-2]
-        return [f'blend.t{hour}z.core.f002.co.grib2',
-                f'blend.t{hour}z.core.f003.co.grib2',
-                f'blend.t{hour}z.core.f004.co.grib2']
+            hour = args[-1].split("/")[-2]
+        return [
+            f"blend.t{hour}z.core.f002.co.grib2",
+            f"blend.t{hour}z.core.f003.co.grib2",
+            f"blend.t{hour}z.core.f004.co.grib2",
+        ]
+
     mock_function = Mock(side_effect=get_files_for_dir)
-    monkeypatch.setattr('idsse.common.aws_utils.exec_cmd', mock_function)
+    monkeypatch.setattr("idsse.common.aws_utils.exec_cmd", mock_function)
     return mock_function
 
 
 # test class methods
 def test_get_path(aws_utils: AwsUtils):
     result_path = aws_utils.get_path(EXAMPLE_ISSUE, EXAMPLE_VALID)
-    assert result_path == f'{EXAMPLE_DIR}blend.t12z.core.f002.co.grib2'
+    assert result_path == f"{EXAMPLE_DIR}blend.t12z.core.f002.co.grib2"
 
 
 def test_ls(aws_utils: AwsUtils, mock_exec_cmd):
     result = aws_utils.ls(EXAMPLE_DIR)
 
     assert len(result) == len(EXAMPLE_FILES)
-    assert result[0] == f'{EXAMPLE_DIR}{EXAMPLE_FILES[0]}'
+    assert result[0] == f"{EXAMPLE_DIR}{EXAMPLE_FILES[0]}"
     mock_exec_cmd.assert_called_once()
 
 
@@ -93,10 +101,8 @@ def test_ls_without_prepend_path(aws_utils: AwsUtils, mock_exec_cmd):
 
 def test_ls_retries_with_s3(aws_utils: AwsUtils, monkeypatch: MonkeyPatch):
     # fails first call, succeeds second call
-    mock_exec_cmd_failure = Mock(
-        side_effect=[FileNotFoundError, EXAMPLE_FILES])
-    monkeypatch.setattr('idsse.common.aws_utils.exec_cmd',
-                        mock_exec_cmd_failure)
+    mock_exec_cmd_failure = Mock(side_effect=[FileNotFoundError, EXAMPLE_FILES])
+    monkeypatch.setattr("idsse.common.aws_utils.exec_cmd", mock_exec_cmd_failure)
 
     result = aws_utils.ls(EXAMPLE_DIR)
     assert len(result) == 3  # ls should have eventually returned good data
@@ -104,9 +110,8 @@ def test_ls_retries_with_s3(aws_utils: AwsUtils, monkeypatch: MonkeyPatch):
 
 
 def test_ls_on_error(aws_utils: AwsUtils, monkeypatch: MonkeyPatch):
-    mock_exec_cmd_failure = Mock(side_effect=PermissionError('No permissions'))
-    monkeypatch.setattr('idsse.common.aws_utils.exec_cmd',
-                        mock_exec_cmd_failure)
+    mock_exec_cmd_failure = Mock(side_effect=PermissionError("No permissions"))
+    monkeypatch.setattr("idsse.common.aws_utils.exec_cmd", mock_exec_cmd_failure)
 
     result = aws_utils.ls(EXAMPLE_DIR)
     assert result == []
@@ -114,29 +119,27 @@ def test_ls_on_error(aws_utils: AwsUtils, monkeypatch: MonkeyPatch):
 
 
 def test_cp_succeeds(aws_utils: AwsUtils, mock_exec_cmd):
-    path = f'{EXAMPLE_DIR}file.grib2.idx'
-    dest = f'{EXAMPLE_DIR}new_file.grib2.idx'
+    path = f"{EXAMPLE_DIR}file.grib2.idx"
+    dest = f"{EXAMPLE_DIR}new_file.grib2.idx"
 
     copy_success = aws_utils.cp(path, dest)
     assert copy_success
 
 
 def test_cp_retries_with_s3_command_line(aws_utils: AwsUtils, monkeypatch: MonkeyPatch):
-    mock_exec_cmd_failure = Mock(
-        side_effect=[FileNotFoundError, ['cp worked']])
-    monkeypatch.setattr('idsse.common.aws_utils.exec_cmd',
-                        mock_exec_cmd_failure)
+    mock_exec_cmd_failure = Mock(side_effect=[FileNotFoundError, ["cp worked"]])
+    monkeypatch.setattr("idsse.common.aws_utils.exec_cmd", mock_exec_cmd_failure)
 
-    copy_success = aws_utils.cp('s3:/some/path', 's3:/new/path')
+    copy_success = aws_utils.cp("s3:/some/path", "s3:/new/path")
     assert copy_success
     assert mock_exec_cmd_failure.call_count == 2
 
 
 def test_cp_permissions_error(aws_utils: AwsUtils, monkeypatch: MonkeyPatch):
     mock_exec_cmd_failure = Mock(side_effect=PermissionError)
-    monkeypatch.setattr('idsse.common.aws_utils.exec_cmd', mock_exec_cmd_failure)
+    monkeypatch.setattr("idsse.common.aws_utils.exec_cmd", mock_exec_cmd_failure)
 
-    copy_success = aws_utils.cp('s3:/some/path', 's3:/new/path')
+    copy_success = aws_utils.cp("s3:/some/path", "s3:/new/path")
 
     assert not copy_success
     # s5cmd throws PermissionError when file not found in AWS; don't bother retrying with aws-cli
@@ -144,11 +147,12 @@ def test_cp_permissions_error(aws_utils: AwsUtils, monkeypatch: MonkeyPatch):
 
 
 def test_cp_fails(aws_utils: AwsUtils, monkeypatch: MonkeyPatch):
-    mock_exec_cmd_failure = Mock(side_effect=[FileNotFoundError,
-                                              Exception('unexpected bad thing happened')])
-    monkeypatch.setattr('idsse.common.aws_utils.exec_cmd', mock_exec_cmd_failure)
+    mock_exec_cmd_failure = Mock(
+        side_effect=[FileNotFoundError, Exception("unexpected bad thing happened")]
+    )
+    monkeypatch.setattr("idsse.common.aws_utils.exec_cmd", mock_exec_cmd_failure)
 
-    copy_success = aws_utils.cp('s3:/some/path', 's3:/new/path')
+    copy_success = aws_utils.cp("s3:/some/path", "s3:/new/path")
 
     assert not copy_success
     assert mock_exec_cmd_failure.call_count == 2
@@ -157,7 +161,7 @@ def test_cp_fails(aws_utils: AwsUtils, monkeypatch: MonkeyPatch):
 def test_check_for_succeeds(aws_utils: AwsUtils, mock_exec_cmd):
     result = aws_utils.check_for(EXAMPLE_ISSUE, EXAMPLE_VALID)
     assert result is not None
-    assert result == (EXAMPLE_VALID, f'{EXAMPLE_DIR}{EXAMPLE_FILES[0]}')
+    assert result == (EXAMPLE_VALID, f"{EXAMPLE_DIR}{EXAMPLE_FILES[0]}")
 
 
 def test_check_for_does_not_find_valid(aws_utils: AwsUtils, mock_exec_cmd):
@@ -167,8 +171,7 @@ def test_check_for_does_not_find_valid(aws_utils: AwsUtils, mock_exec_cmd):
 
 
 def test_get_issues(aws_utils: AwsUtils, mock_exec_cmd):
-    result = aws_utils.get_issues(
-        issue_start=EXAMPLE_ISSUE, issue_end=EXAMPLE_VALID, num_issues=2)
+    result = aws_utils.get_issues(issue_start=EXAMPLE_ISSUE, issue_end=EXAMPLE_VALID, num_issues=2)
     assert len(result) == 2
     assert result[0] == EXAMPLE_VALID - timedelta(hours=1)
     assert result[1] == EXAMPLE_VALID
@@ -180,14 +183,16 @@ def test_get_issues_with_same_start_stop(aws_utils: AwsUtils, mock_exec_cmd):
     assert result[0] == EXAMPLE_ISSUE
 
 
-def test_get_issues_latest_issue_default_today(aws_utils: AwsUtils,
-                                               mock_exec_cmd: Mock,
-                                               monkeypatch: MonkeyPatch):
+def test_get_issues_latest_issue_default_today(
+    aws_utils: AwsUtils, mock_exec_cmd: Mock, monkeypatch: MonkeyPatch
+):
     # first time .now() is called, it's 12:59. Next call, it's 13:01
-    example_datetimes = [datetime(2025, 1, 1, 12, 59, tzinfo=UTC),
-                         datetime(2025, 1, 1, 13, 1, tzinfo=UTC)]
+    example_datetimes = [
+        datetime(2025, 1, 1, 12, 59, tzinfo=UTC),
+        datetime(2025, 1, 1, 13, 1, tzinfo=UTC),
+    ]
     mock_datetime = Mock(spec=datetime, now=Mock(side_effect=example_datetimes))
-    monkeypatch.setattr('idsse.common.protocol_utils.datetime', mock_datetime)
+    monkeypatch.setattr("idsse.common.protocol_utils.datetime", mock_datetime)
 
     result = aws_utils.get_issues()
     # with current mocks returned issue (latest issue) will always be "now" with
@@ -197,7 +202,7 @@ def test_get_issues_latest_issue_default_today(aws_utils: AwsUtils,
     assert result[0] == example_datetimes[0].replace(minute=0)
     # should have ls'd the 12Z directory in AWS
     aws_dir = mock_exec_cmd.call_args[0][0][3]
-    assert aws_utils.path_builder.parse_dir(aws_dir)['issue.hour'] == example_datetimes[0].hour
+    assert aws_utils.path_builder.parse_dir(aws_dir)["issue.hour"] == example_datetimes[0].hour
 
     # simulate the passage of time: it's now 13:01 and a new 13Z issueDt has appeared
     result = aws_utils.get_issues()
@@ -205,24 +210,23 @@ def test_get_issues_latest_issue_default_today(aws_utils: AwsUtils,
     assert result[0] == example_datetimes[1].replace(minute=0)
     # should have ls'd the 13Z directory in AWS
     aws_dir = mock_exec_cmd.call_args[0][0][3]
-    assert aws_utils.path_builder.parse_dir(aws_dir)['issue.hour'] == example_datetimes[1].hour
-
+    assert aws_utils.path_builder.parse_dir(aws_dir)["issue.hour"] == example_datetimes[1].hour
 
 
 def test_get_valids_all(aws_utils: AwsUtils, mock_exec_cmd):
     result = aws_utils.get_valids(EXAMPLE_ISSUE)
     assert len(result) == 3
-    assert result[0] == (EXAMPLE_VALID, f'{EXAMPLE_DIR}{EXAMPLE_FILES[0]}')
-    assert result[1] == (EXAMPLE_VALID + timedelta(hours=1), f'{EXAMPLE_DIR}{EXAMPLE_FILES[1]}')
-    assert result[2] == (EXAMPLE_VALID + timedelta(hours=2), f'{EXAMPLE_DIR}{EXAMPLE_FILES[2]}')
+    assert result[0] == (EXAMPLE_VALID, f"{EXAMPLE_DIR}{EXAMPLE_FILES[0]}")
+    assert result[1] == (EXAMPLE_VALID + timedelta(hours=1), f"{EXAMPLE_DIR}{EXAMPLE_FILES[1]}")
+    assert result[2] == (EXAMPLE_VALID + timedelta(hours=2), f"{EXAMPLE_DIR}{EXAMPLE_FILES[2]}")
 
 
 def test_get_valids_with_start_filter(aws_utils: AwsUtils, mock_exec_cmd):
     valid_start = EXAMPLE_VALID + timedelta(hours=1)
     result = aws_utils.get_valids(EXAMPLE_ISSUE, valid_start=valid_start)
     assert len(result) == 2
-    assert result[0] == (valid_start, f'{EXAMPLE_DIR}{EXAMPLE_FILES[1]}')
-    assert result[1] == (valid_start + timedelta(hours=1), f'{EXAMPLE_DIR}{EXAMPLE_FILES[2]}')
+    assert result[0] == (valid_start, f"{EXAMPLE_DIR}{EXAMPLE_FILES[1]}")
+    assert result[1] == (valid_start + timedelta(hours=1), f"{EXAMPLE_DIR}{EXAMPLE_FILES[2]}")
 
 
 def test_get_valids_with_start_and_end_filer(aws_utils: AwsUtils, mock_exec_cmd):
@@ -230,19 +234,17 @@ def test_get_valids_with_start_and_end_filer(aws_utils: AwsUtils, mock_exec_cmd)
     valid_end = EXAMPLE_VALID + timedelta(hours=1)
     result = aws_utils.get_valids(EXAMPLE_ISSUE, valid_start=valid_start, valid_end=valid_end)
     assert len(result) == 2
-    assert result[0] == (valid_start, f'{EXAMPLE_DIR}{EXAMPLE_FILES[0]}')
-    assert result[1] == (valid_end, f'{EXAMPLE_DIR}{EXAMPLE_FILES[1]}')
+    assert result[0] == (valid_start, f"{EXAMPLE_DIR}{EXAMPLE_FILES[0]}")
+    assert result[1] == (valid_end, f"{EXAMPLE_DIR}{EXAMPLE_FILES[1]}")
 
 
 def test_get_valids_with_same_start_end_filer(aws_utils: AwsUtils, mock_exec_cmd):
     valid_start = EXAMPLE_VALID
     valid_end = EXAMPLE_VALID + timedelta(hours=1)
-    result_same = aws_utils.get_valids(EXAMPLE_ISSUE,
-                                       valid_start=valid_start,
-                                       valid_end=valid_start)
-    result_diff = aws_utils.get_valids(EXAMPLE_ISSUE,
-                                       valid_start=valid_start,
-                                       valid_end=valid_end)
+    result_same = aws_utils.get_valids(
+        EXAMPLE_ISSUE, valid_start=valid_start, valid_end=valid_start
+    )
+    result_diff = aws_utils.get_valids(EXAMPLE_ISSUE, valid_start=valid_start, valid_end=valid_end)
     assert len(result_same) == 1
     assert len(result_diff) == 2
     assert result_same[0] == result_diff[0]
@@ -251,6 +253,6 @@ def test_get_valids_with_same_start_end_filer(aws_utils: AwsUtils, mock_exec_cmd
 def test_get_valids_with_wildcards(aws_utils_with_wild: AwsUtils, mock_exec_cmd):
     result = aws_utils_with_wild.get_valids(EXAMPLE_ISSUE)
     assert len(result) == 3
-    assert result[0] == (EXAMPLE_VALID, f'{EXAMPLE_DIR}{EXAMPLE_FILES[0]}')
-    assert result[1] == (EXAMPLE_VALID + timedelta(hours=1), f'{EXAMPLE_DIR}{EXAMPLE_FILES[1]}')
-    assert result[2] == (EXAMPLE_VALID + timedelta(hours=2), f'{EXAMPLE_DIR}{EXAMPLE_FILES[2]}')
+    assert result[0] == (EXAMPLE_VALID, f"{EXAMPLE_DIR}{EXAMPLE_FILES[0]}")
+    assert result[1] == (EXAMPLE_VALID + timedelta(hours=1), f"{EXAMPLE_DIR}{EXAMPLE_FILES[1]}")
+    assert result[2] == (EXAMPLE_VALID + timedelta(hours=2), f"{EXAMPLE_DIR}{EXAMPLE_FILES[2]}")

--- a/python/idsse_common/test/test_config.py
+++ b/python/idsse_common/test/test_config.py
@@ -1,4 +1,5 @@
 """Test suit for config.py"""
+
 # --------------------------------------------------------------------------------
 # Created on Fri Mar 17 2023
 #
@@ -24,10 +25,10 @@ def test_load_from_dict_without_key():
 
         def __init__(self, config: dict) -> None:
             self.a_key = None
-            super().__init__(config, '')
+            super().__init__(config, "")
 
-    config = WithoutKeyConfig({'a_key': 'value found'})
-    assert config.a_key == 'value found'
+    config = WithoutKeyConfig({"a_key": "value found"})
+    assert config.a_key == "value found"
 
 
 def test_load_from_dict_as_string_without_key():
@@ -36,10 +37,10 @@ def test_load_from_dict_as_string_without_key():
 
         def __init__(self, config: dict) -> None:
             self.some_key = None
-            super().__init__(config, '')
+            super().__init__(config, "")
 
     config = WithoutKeyConfig('{"some_key": "value found"}')
-    assert config.some_key == 'value found'
+    assert config.some_key == "value found"
 
 
 def test_load_from_dict_with_name_key():
@@ -50,8 +51,8 @@ def test_load_from_dict_with_name_key():
             self.best_key = None
             super().__init__(config, None)
 
-    config = NameAsKeyConfig({'NameAsKeyConfig': {'best_key': 'value found'}})
-    assert config.best_key == 'value found'
+    config = NameAsKeyConfig({"NameAsKeyConfig": {"best_key": "value found"}})
+    assert config.best_key == "value found"
 
 
 def test_load_from_dict_require_string_key():
@@ -62,9 +63,8 @@ def test_load_from_dict_require_string_key():
             self.some_key = None
             super().__init__(config, key)
 
-    config = RequireKeyConfig(
-        '{"custom_key": {"some_key": "value found"}}', 'custom_key')
-    assert config.some_key == 'value found'
+    config = RequireKeyConfig('{"custom_key": {"some_key": "value found"}}', "custom_key")
+    assert config.some_key == "value found"
 
 
 def test_load_from_dict_require_list_key():
@@ -75,10 +75,11 @@ def test_load_from_dict_require_list_key():
             self.some_key = None
             super().__init__(config, key)
 
-    key_list = ['custom_key', 'custom_key2']
-    config = RequireKeyConfig('{"custom_key": {"custom_key2": {"some_key": "value found"}}}',
-                              key_list)
-    assert config.some_key == 'value found'
+    key_list = ["custom_key", "custom_key2"]
+    config = RequireKeyConfig(
+        '{"custom_key": {"custom_key2": {"some_key": "value found"}}}', key_list
+    )
+    assert config.some_key == "value found"
 
 
 def test_load_with_missing_attribute_should_fail():
@@ -87,10 +88,10 @@ def test_load_with_missing_attribute_should_fail():
 
         def __init__(self, config: dict) -> None:
             self.a_key = None
-            super().__init__(config, '')
+            super().__init__(config, "")
 
     with raises(NameError) as exc:
-        WithoutKeyConfig({'diff_key': 'value found'})
+        WithoutKeyConfig({"diff_key": "value found"})
     assert exc is not None
 
 
@@ -100,12 +101,12 @@ def test_config_str_with_no_files_raises_error(monkeypatch: MonkeyPatch):
 
         def __init__(self, config: str) -> None:
             self.a_key = None
-            super().__init__(config, '')
+            super().__init__(config, "")
 
-    monkeypatch.setattr('glob.glob', Mock(return_value=[]))
+    monkeypatch.setattr("glob.glob", Mock(return_value=[]))
 
     with raises(FileNotFoundError) as exc:
-        WithoutKeyConfig('wont_be_found')
+        WithoutKeyConfig("wont_be_found")
     assert exc is not None
 
 
@@ -116,15 +117,14 @@ def test_config_list_of_dicts_succeeds():
         def __init__(self, config: dict) -> None:
             self.a_key = None
             self.b_key = None
-            super().__init__(config, keys='', ignore_missing=True)
+            super().__init__(config, keys="", ignore_missing=True)
 
-    config = WithoutKeyConfig([{'a_key': 'value for a'},
-                               {'b_key': 'value for b'}])
+    config = WithoutKeyConfig([{"a_key": "value for a"}, {"b_key": "value for b"}])
 
-    assert config.a_key == 'value for a'
+    assert config.a_key == "value for a"
     config = config.next
-    assert config.b_key == 'value for b'
-    assert config.first.a_key == 'value for a'
+    assert config.b_key == "value for b"
+    assert config.first.a_key == "value for a"
 
 
 def test_load_with_ignore_missing_attribute():
@@ -134,10 +134,10 @@ def test_load_with_ignore_missing_attribute():
         def __init__(self, config: dict) -> None:
             self.a_key = None
             self.b_key = None
-            super().__init__(config, '', ignore_missing=True)
+            super().__init__(config, "", ignore_missing=True)
 
-    config = WithoutKeyConfig({'a_key': 'value for a'})
-    assert config.a_key == 'value for a'
+    config = WithoutKeyConfig({"a_key": "value for a"})
+    assert config.a_key == "value for a"
 
 
 def test_load_from_file(monkeypatch: MonkeyPatch):
@@ -146,14 +146,14 @@ def test_load_from_file(monkeypatch: MonkeyPatch):
 
         def __init__(self, config: dict) -> None:
             self.y_this_is_a_key = None
-            super().__init__(config, '')
+            super().__init__(config, "")
 
-    monkeypatch.setattr('glob.glob', Mock(return_value=['filename']))
+    monkeypatch.setattr("glob.glob", Mock(return_value=["filename"]))
 
     read_data = json.dumps({"y_this_is_a_key": "value found in file"})
-    monkeypatch.setattr('builtins.open', mock_open(read_data=read_data))
+    monkeypatch.setattr("builtins.open", mock_open(read_data=read_data))
 
-    config = WithoutKeyConfig('path/to/file')
+    config = WithoutKeyConfig("path/to/file")
 
     assert config.y_this_is_a_key == "value found in file"
 
@@ -166,16 +166,16 @@ def test_load_from_files_with_out_key(monkeypatch: MonkeyPatch):
             self.y_this_is_a_key = None
             super().__init__(config, [])
 
-    monkeypatch.setattr('glob.glob', Mock(
-        return_value=['filename1', 'filename2']))
+    monkeypatch.setattr("glob.glob", Mock(return_value=["filename1", "filename2"]))
 
-    read_data = [json.dumps({"y_this_is_a_key": "value found in file1"}),
-                 json.dumps({"y_this_is_a_key": "value found in file2"})]
-    mock_files = Mock(side_effect=(
-        mock_open(read_data=data).return_value for data in read_data))
-    monkeypatch.setattr('builtins.open', mock_files)
+    read_data = [
+        json.dumps({"y_this_is_a_key": "value found in file1"}),
+        json.dumps({"y_this_is_a_key": "value found in file2"}),
+    ]
+    mock_files = Mock(side_effect=(mock_open(read_data=data).return_value for data in read_data))
+    monkeypatch.setattr("builtins.open", mock_files)
 
-    config = WithoutKeyConfig('path/to/dir')
+    config = WithoutKeyConfig("path/to/dir")
 
     assert config.y_this_is_a_key == "value found in file1"
     assert config.next.y_this_is_a_key == "value found in file2"
@@ -188,18 +188,18 @@ def test_load_from_files_with_key(monkeypatch: MonkeyPatch):
 
         def __init__(self, config: dict) -> None:
             self.y_this_is_a_key = None
-            super().__init__(config, 'config_key')
+            super().__init__(config, "config_key")
 
-    monkeypatch.setattr('glob.glob', Mock(
-        return_value=['filename1', 'filename2']))
+    monkeypatch.setattr("glob.glob", Mock(return_value=["filename1", "filename2"]))
 
-    read_data = [json.dumps({"config_key": {"y_this_is_a_key": "value found in file1"}}),
-                 json.dumps({"config_key": {"y_this_is_a_key": "value found in file2"}})]
-    mock_files = Mock(side_effect=(
-        mock_open(read_data=data).return_value for data in read_data))
-    monkeypatch.setattr('builtins.open', mock_files)
+    read_data = [
+        json.dumps({"config_key": {"y_this_is_a_key": "value found in file1"}}),
+        json.dumps({"config_key": {"y_this_is_a_key": "value found in file2"}}),
+    ]
+    mock_files = Mock(side_effect=(mock_open(read_data=data).return_value for data in read_data))
+    monkeypatch.setattr("builtins.open", mock_files)
 
-    config = WithoutKeyConfig('path/to/dir')
+    config = WithoutKeyConfig("path/to/dir")
 
     assert config.y_this_is_a_key == "value found in file1"
     assert config.next.y_this_is_a_key == "value found in file2"

--- a/python/idsse_common/test/test_http_utils.py
+++ b/python/idsse_common/test/test_http_utils.py
@@ -1,4 +1,5 @@
 """Test suite for http_utils.py"""
+
 # ----------------------------------------------------------------------------------
 # Created on Tue Dec 3
 #
@@ -24,156 +25,187 @@ from idsse.testing.utils.resources import get_resource_from_file
 EXAMPLE_ISSUE = datetime(2024, 10, 30, 20, 56, 40, tzinfo=UTC)
 EXAMPLE_VALID = datetime(2024, 10, 30, 20, 56, 40, tzinfo=UTC)
 
-EXAMPLE_URL = 'http://127.0.0.1:5000/data/'
-EXAMPLE_ENDPOINT = '3DRefl/MergedReflectivityQC_00.50'
-EXAMPLE_PROD_DIR = '3DRefl/MergedReflectivityQC_00.50/'
-EXAMPLE_FILES = ['MRMS_MergedReflectivityQC_00.50.latest.grib2.gz',
-                 'MRMS_MergedReflectivityQC_00.50_20241030-205438.grib2.gz',
-                 'MRMS_MergedReflectivityQC_00.50_20241030-205640.grib2.gz']
+EXAMPLE_URL = "http://127.0.0.1:5000/data/"
+EXAMPLE_ENDPOINT = "3DRefl/MergedReflectivityQC_00.50"
+EXAMPLE_PROD_DIR = "3DRefl/MergedReflectivityQC_00.50/"
+EXAMPLE_FILES = [
+    "MRMS_MergedReflectivityQC_00.50.latest.grib2.gz",
+    "MRMS_MergedReflectivityQC_00.50_20241030-205438.grib2.gz",
+    "MRMS_MergedReflectivityQC_00.50_20241030-205640.grib2.gz",
+]
 
-EXAMPLE_VALID_FILES = ['MRMS_MergedReflectivityQC_00.50.latest.grib2.gz',
-                       'MRMS_MergedReflectivityQC_00.50_20241030-205438_20241030-205438.grib2.gz',
-                       'MRMS_MergedReflectivityQC_00.50_20241030-205640_20241030-205640.grib2.gz']
+EXAMPLE_VALID_FILES = [
+    "MRMS_MergedReflectivityQC_00.50.latest.grib2.gz",
+    "MRMS_MergedReflectivityQC_00.50_20241030-205438_20241030-205438.grib2.gz",
+    "MRMS_MergedReflectivityQC_00.50_20241030-205640_20241030-205640.grib2.gz",
+]
 
-EXAMPLE_RETURN = get_resource_from_file('idsse.testing.idsse_common',
-                                        'mrms_response.html')
-EXAMPLE_VALID_RETURN = get_resource_from_file('idsse.testing.idsse_common',
-                                              'mrms_valid_response.html')
+EXAMPLE_RETURN = get_resource_from_file("idsse.testing.idsse_common", "mrms_response.html")
+EXAMPLE_VALID_RETURN = get_resource_from_file(
+    "idsse.testing.idsse_common", "mrms_valid_response.html"
+)
+
 
 # fixtures
 @fixture(scope="session")
 def httpserver_listen_address():
     return "127.0.0.1", 5000
 
+
 @fixture
 def http_utils() -> HttpUtils:
-    EXAMPLE_BASE_DIR = 'http://127.0.0.1:5000/data/'
-    EXAMPLE_SUB_DIR = '3DRefl/MergedReflectivityQC_00.50/'
-    EXAMPLE_FILE_BASE = ('MRMS_MergedReflectivityQC_00.50_'
-                         '{issue.year:04d}{issue.month:02d}{issue.day:02d}'
-                         '-{issue.hour:02d}{issue.minute:02d}{issue.second:02d}')
-    EXAMPLE_FILE_EXT = '.grib2.gz'
+    EXAMPLE_BASE_DIR = "http://127.0.0.1:5000/data/"
+    EXAMPLE_SUB_DIR = "3DRefl/MergedReflectivityQC_00.50/"
+    EXAMPLE_FILE_BASE = (
+        "MRMS_MergedReflectivityQC_00.50_"
+        "{issue.year:04d}{issue.month:02d}{issue.day:02d}"
+        "-{issue.hour:02d}{issue.minute:02d}{issue.second:02d}"
+    )
+    EXAMPLE_FILE_EXT = ".grib2.gz"
 
     return HttpUtils(EXAMPLE_BASE_DIR, EXAMPLE_SUB_DIR, EXAMPLE_FILE_BASE, EXAMPLE_FILE_EXT)
 
+
 @fixture
 def http_utils_with_valid() -> HttpUtils:
-    EXAMPLE_BASE_DIR = 'http://127.0.0.1:5000/data/'
-    EXAMPLE_SUB_DIR = '3DRefl/MergedReflectivityQC_00.50/'
-    EXAMPLE_FILE_BASE = ('MRMS_MergedReflectivityQC_00.50_'
-                         '{issue.year:04d}{issue.month:02d}{issue.day:02d}'
-                         '-{issue.hour:02d}{issue.minute:02d}{issue.second:02d}_'
-                         '{valid.year:04d}{valid.month:02d}{valid.day:02d}'
-                         '-{valid.hour:02d}{valid.minute:02d}{valid.second:02d}')
-    EXAMPLE_FILE_EXT = '.grib2.gz'
+    EXAMPLE_BASE_DIR = "http://127.0.0.1:5000/data/"
+    EXAMPLE_SUB_DIR = "3DRefl/MergedReflectivityQC_00.50/"
+    EXAMPLE_FILE_BASE = (
+        "MRMS_MergedReflectivityQC_00.50_"
+        "{issue.year:04d}{issue.month:02d}{issue.day:02d}"
+        "-{issue.hour:02d}{issue.minute:02d}{issue.second:02d}_"
+        "{valid.year:04d}{valid.month:02d}{valid.day:02d}"
+        "-{valid.hour:02d}{valid.minute:02d}{valid.second:02d}"
+    )
+    EXAMPLE_FILE_EXT = ".grib2.gz"
 
     return HttpUtils(EXAMPLE_BASE_DIR, EXAMPLE_SUB_DIR, EXAMPLE_FILE_BASE, EXAMPLE_FILE_EXT)
 
 
 @fixture
 def http_utils_with_wild() -> HttpUtils:
-    EXAMPLE_BASE_DIR = 'http://127.0.0.1:5000/data/'
-    EXAMPLE_SUB_DIR = '3DRefl/MergedReflectivityQC_00.50/'
-    EXAMPLE_FILE_BASE = ('MRMS_MergedReflectivityQC_00.50_{issue.year:04d}{issue.month:02d}{issue.day:02d}'
-                         '-{issue.hour:02d}{issue.minute:02d}?{issue.second:02d}')
-    EXAMPLE_FILE_EXT = '.grib2.gz'
+    EXAMPLE_BASE_DIR = "http://127.0.0.1:5000/data/"
+    EXAMPLE_SUB_DIR = "3DRefl/MergedReflectivityQC_00.50/"
+    EXAMPLE_FILE_BASE = (
+        "MRMS_MergedReflectivityQC_00.50_{issue.year:04d}{issue.month:02d}{issue.day:02d}"
+        "-{issue.hour:02d}{issue.minute:02d}?{issue.second:02d}"
+    )
+    EXAMPLE_FILE_EXT = ".grib2.gz"
 
     return HttpUtils(EXAMPLE_BASE_DIR, EXAMPLE_SUB_DIR, EXAMPLE_FILE_BASE, EXAMPLE_FILE_EXT)
+
 
 # test class methods
 def test_get_path(http_utils: HttpUtils):
     result_path = http_utils.get_path(EXAMPLE_ISSUE, EXAMPLE_VALID)
-    assert result_path == f'{EXAMPLE_URL}{EXAMPLE_PROD_DIR}MRMS_MergedReflectivityQC_00.50_20241030-205640.grib2.gz'
+    assert (
+        result_path
+        == f"{EXAMPLE_URL}{EXAMPLE_PROD_DIR}MRMS_MergedReflectivityQC_00.50_20241030-205640.grib2.gz"
+    )
 
 
 def test_ls(http_utils: HttpUtils, httpserver: HTTPServer):
-    httpserver.expect_request('/data/'+EXAMPLE_ENDPOINT).respond_with_data(EXAMPLE_RETURN,
-                                                                           content_type="text/plain")
+    httpserver.expect_request("/data/" + EXAMPLE_ENDPOINT).respond_with_data(
+        EXAMPLE_RETURN, content_type="text/plain"
+    )
     result = http_utils.ls(EXAMPLE_URL + EXAMPLE_ENDPOINT)
     assert len(result) == len(EXAMPLE_FILES)
-    assert result[0] == f'{EXAMPLE_URL}{EXAMPLE_PROD_DIR}{EXAMPLE_FILES[-1]}'
+    assert result[0] == f"{EXAMPLE_URL}{EXAMPLE_PROD_DIR}{EXAMPLE_FILES[-1]}"
+
 
 def test_ls_error(http_utils: HttpUtils, httpserver: HTTPServer):
-    httpserver.expect_request('/error/'+EXAMPLE_ENDPOINT).respond_with_data([],
-                                                                           content_type="text/plain")
+    httpserver.expect_request("/error/" + EXAMPLE_ENDPOINT).respond_with_data(
+        [], content_type="text/plain"
+    )
     result = http_utils.ls(EXAMPLE_URL + EXAMPLE_ENDPOINT)
     assert len(result) == 0
 
+
 def test_ls_without_prepend_path(http_utils: HttpUtils, httpserver: HTTPServer):
-    httpserver.expect_request('/data/'+EXAMPLE_ENDPOINT).respond_with_data(EXAMPLE_RETURN,
-                                                                           content_type="text/plain")
+    httpserver.expect_request("/data/" + EXAMPLE_ENDPOINT).respond_with_data(
+        EXAMPLE_RETURN, content_type="text/plain"
+    )
     result = http_utils.ls(EXAMPLE_URL + EXAMPLE_ENDPOINT, prepend_path=False)
     assert len(result) == len(EXAMPLE_FILES)
     assert result[0] == EXAMPLE_FILES[-1]
 
+
 def test_cp_succeeds(http_utils: HttpUtils, httpserver: HTTPServer):
-    url = '/data/'+EXAMPLE_PROD_DIR+'/temp.grib2.gz'
-    httpserver.expect_request(url).respond_with_data(bytes([0,1,2]), status=200,
-                                                     content_type="application/octet-stream")
-    path = f'{EXAMPLE_URL}{EXAMPLE_PROD_DIR}/temp.grib2.gz'
-    dest = '/tmp/temp.grib2.gz'
+    url = "/data/" + EXAMPLE_PROD_DIR + "/temp.grib2.gz"
+    httpserver.expect_request(url).respond_with_data(
+        bytes([0, 1, 2]), status=200, content_type="application/octet-stream"
+    )
+    path = f"{EXAMPLE_URL}{EXAMPLE_PROD_DIR}/temp.grib2.gz"
+    dest = "/tmp/temp.grib2.gz"
 
     copy_success = http_utils.cp(path, dest)
     assert copy_success
 
+
 def test_cp_fails(http_utils: HttpUtils, httpserver: HTTPServer):
-    url = '/data/'+EXAMPLE_PROD_DIR+'/temp.grib2.gz'
-    httpserver.expect_request(url).respond_with_data(bytes([0, 1, 2]), status=404,
-                                                     content_type="application/octet-stream")
-    path = f'{EXAMPLE_URL}{EXAMPLE_PROD_DIR}/temp.grib2.gz'
-    dest = '/tmp/temp.grib2.gz'
+    url = "/data/" + EXAMPLE_PROD_DIR + "/temp.grib2.gz"
+    httpserver.expect_request(url).respond_with_data(
+        bytes([0, 1, 2]), status=404, content_type="application/octet-stream"
+    )
+    path = f"{EXAMPLE_URL}{EXAMPLE_PROD_DIR}/temp.grib2.gz"
+    dest = "/tmp/temp.grib2.gz"
     copy_success = http_utils.cp(path, dest)
     assert not copy_success
 
 
 def test_check_for_succeeds(http_utils: HttpUtils, httpserver: HTTPServer):
-    url = '/data/'+EXAMPLE_ENDPOINT
+    url = "/data/" + EXAMPLE_ENDPOINT
     httpserver.expect_request(url).respond_with_data(EXAMPLE_RETURN, content_type="text/plain")
 
     result = http_utils.check_for(EXAMPLE_ISSUE, EXAMPLE_VALID)
     assert result is not None
-    assert result == (EXAMPLE_VALID, f'{EXAMPLE_URL}{EXAMPLE_PROD_DIR}{EXAMPLE_FILES[-1]}')
+    assert result == (EXAMPLE_VALID, f"{EXAMPLE_URL}{EXAMPLE_PROD_DIR}{EXAMPLE_FILES[-1]}")
 
 
 def test_check_for_does_not_find_valid(http_utils: HttpUtils, httpserver: HTTPServer):
-    url = '/data/'+EXAMPLE_ENDPOINT
-    httpserver.expect_request(url).respond_with_data('', content_type="text/plain")
+    url = "/data/" + EXAMPLE_ENDPOINT
+    httpserver.expect_request(url).respond_with_data("", content_type="text/plain")
     unexpected_valid = datetime(1970, 10, 3, 23, tzinfo=UTC)
     result = http_utils.check_for(EXAMPLE_ISSUE, unexpected_valid)
     assert result is None
 
 
 def test_get_issues(http_utils: HttpUtils, httpserver: HTTPServer):
-    url = '/data/' + EXAMPLE_ENDPOINT +'/'
+    url = "/data/" + EXAMPLE_ENDPOINT + "/"
     httpserver.expect_request(url).respond_with_data(EXAMPLE_RETURN, content_type="text/plain")
-    result = http_utils.get_issues(issue_start=EXAMPLE_ISSUE,
-                                   time_delta=timedelta(minutes=1))
+    result = http_utils.get_issues(issue_start=EXAMPLE_ISSUE, time_delta=timedelta(minutes=1))
     assert len(result) == 1
     assert result[0] == EXAMPLE_ISSUE
 
 
 def test_get_issues_with_same_start_stop(http_utils: HttpUtils, httpserver: HTTPServer):
-    url = '/data/'+EXAMPLE_ENDPOINT+'/'
+    url = "/data/" + EXAMPLE_ENDPOINT + "/"
     httpserver.expect_request(url).respond_with_data(EXAMPLE_RETURN, content_type="text/plain")
-    result = http_utils.get_issues(issue_start=EXAMPLE_ISSUE, issue_end=EXAMPLE_ISSUE, time_delta=timedelta(minutes=1))
+    result = http_utils.get_issues(
+        issue_start=EXAMPLE_ISSUE, issue_end=EXAMPLE_ISSUE, time_delta=timedelta(minutes=1)
+    )
     assert len(result) == 1
     assert result[0] == EXAMPLE_ISSUE
 
+
 def test_get_valids(http_utils: HttpUtils, httpserver: HTTPServer):
-    url = '/data/'+EXAMPLE_ENDPOINT+'/'
+    url = "/data/" + EXAMPLE_ENDPOINT + "/"
     httpserver.expect_request(url).respond_with_data(EXAMPLE_RETURN, content_type="text/plain")
     result = http_utils.get_valids(EXAMPLE_ISSUE)
     assert len(result) == 0
 
+
 def test_get_valids_all(http_utils_with_valid: HttpUtils, httpserver: HTTPServer):
-    url = '/data/'+EXAMPLE_ENDPOINT+'/'
-    httpserver.expect_request(url).respond_with_data(EXAMPLE_VALID_RETURN, content_type="text/plain")
+    url = "/data/" + EXAMPLE_ENDPOINT + "/"
+    httpserver.expect_request(url).respond_with_data(
+        EXAMPLE_VALID_RETURN, content_type="text/plain"
+    )
     result = http_utils_with_valid.get_valids(EXAMPLE_ISSUE)
     assert len(result) == 1
 
 
 def test_get_valids_with_wildcards(http_utils_with_wild: HttpUtils, httpserver: HTTPServer):
-    url = '/data/'+EXAMPLE_ENDPOINT+'/'
+    url = "/data/" + EXAMPLE_ENDPOINT + "/"
     httpserver.expect_request(url).respond_with_data(EXAMPLE_RETURN, content_type="text/plain")
     result = http_utils_with_wild.get_valids(EXAMPLE_ISSUE)
     assert len(result) == 0

--- a/python/idsse_common/test/test_json_message.py
+++ b/python/idsse_common/test/test_json_message.py
@@ -1,4 +1,5 @@
 """Test suite for json_message.py"""
+
 # ----------------------------------------------------------------------------------
 # Created on Fri Oct 20 2023
 #
@@ -19,14 +20,12 @@ from idsse.common.json_message import get_corr_id, add_corr_id
 from idsse.common.utils import to_iso
 
 # test data
-EXAMPLE_ORIGINATOR = 'idsse'
+EXAMPLE_ORIGINATOR = "idsse"
 EXAMPLE_UUID = str(uuid())
 EXAMPLE_ISSUE_DT = to_iso(datetime.now(UTC))
 
 EXAMPLE_MESSAGE = {
-    'corrId': {
-        'originator': EXAMPLE_ORIGINATOR, 'uuid': EXAMPLE_UUID, 'issueDt': EXAMPLE_ISSUE_DT
-    }
+    "corrId": {"originator": EXAMPLE_ORIGINATOR, "uuid": EXAMPLE_UUID, "issueDt": EXAMPLE_ISSUE_DT}
 }
 
 
@@ -41,46 +40,46 @@ def test_get_corr_id_str():
 
 
 def test_get_corr_id_empty_corr_id():
-    result = get_corr_id({'other_data': 123})
+    result = get_corr_id({"other_data": 123})
     assert result is None
 
 
 def test_get_corr_id_originator():
-    result = get_corr_id({'corrId': {'originator': EXAMPLE_ORIGINATOR}})
+    result = get_corr_id({"corrId": {"originator": EXAMPLE_ORIGINATOR}})
     assert result == (EXAMPLE_ORIGINATOR, None, None)
 
 
 def test_get_corr_id_uuid():
-    result = get_corr_id({'corrId': {'uuid': EXAMPLE_UUID}})
+    result = get_corr_id({"corrId": {"uuid": EXAMPLE_UUID}})
     assert result == (None, EXAMPLE_UUID, None)
 
 
 def test_get_corr_id_issue_dt():
-    result = get_corr_id({'corrId': {'issueDt': EXAMPLE_ISSUE_DT}})
+    result = get_corr_id({"corrId": {"issueDt": EXAMPLE_ISSUE_DT}})
     assert result == (None, None, EXAMPLE_ISSUE_DT)
 
 
 def test_json_get_corr_id_failure():
-    bad_message = {'invalid': 'message'}
+    bad_message = {"invalid": "message"}
     result = get_corr_id(bad_message)
     assert result is None
 
 
 def test_add_corr_id():
-    new_originator = 'different_app'
+    new_originator = "different_app"
     new_message = add_corr_id(EXAMPLE_MESSAGE, new_originator)
 
     # blank issueDt and random uuid should have been returned
-    result = new_message['corrId']
-    assert result['originator'] == new_originator
-    assert result['issueDt'] == '_'
-    assert result['uuid'] != EXAMPLE_UUID
+    result = new_message["corrId"]
+    assert result["originator"] == new_originator
+    assert result["issueDt"] == "_"
+    assert result["uuid"] != EXAMPLE_UUID
 
 
 def test_add_corr_id_str():
-    new_originator = 'different_app'
+    new_originator = "different_app"
     new_message = add_corr_id(json.dumps(EXAMPLE_MESSAGE), new_originator)
-    assert new_message['corrId']['originator'] == new_originator
+    assert new_message["corrId"]["originator"] == new_originator
 
 
 def test_add_corr_id_uuid():
@@ -88,11 +87,11 @@ def test_add_corr_id_uuid():
     new_message = add_corr_id(EXAMPLE_MESSAGE, EXAMPLE_ORIGINATOR, uuid_=new_uuid)
 
     # blank issueDt and random uuid should have been returned
-    assert new_message['corrId']['uuid'] == str(new_uuid)
-    assert new_message['corrId']['originator'] == EXAMPLE_ORIGINATOR
+    assert new_message["corrId"]["uuid"] == str(new_uuid)
+    assert new_message["corrId"]["originator"] == EXAMPLE_ORIGINATOR
 
 
 def test_add_corr_id_issue_dt():
     new_issue = to_iso(datetime.now(UTC))
     new_message = add_corr_id(EXAMPLE_MESSAGE, EXAMPLE_ORIGINATOR, issue_dt=new_issue)
-    assert new_message['corrId']['issueDt'] == new_issue
+    assert new_message["corrId"]["issueDt"] == new_issue

--- a/python/idsse_common/test/test_log_util.py
+++ b/python/idsse_common/test/test_log_util.py
@@ -1,4 +1,5 @@
 """Test suite for json_message.py"""
+
 # ----------------------------------------------------------------------------------
 # Created on Fri Oct 20 2023
 #
@@ -25,18 +26,18 @@ from idsse.common.log_util import (
     get_corr_id_context_var_parts,
     get_corr_id_context_var_str,
     get_default_log_config,
-    AddCorrelationIdFilter
+    AddCorrelationIdFilter,
 )
 from idsse.common.utils import to_iso
 
 logger = logging.getLogger(__name__)
 
 # test data
-EXAMPLE_ORIGINATOR = 'idsse'
+EXAMPLE_ORIGINATOR = "idsse"
 EXAMPLE_UUID = uuid()
 EXAMPLE_ISSUE_DT = datetime.now(UTC)
 EXAMPLE_ISSUE_STR = to_iso(EXAMPLE_ISSUE_DT)
-EXAMPLE_LOG_MESSAGE = 'hello world'
+EXAMPLE_LOG_MESSAGE = "hello world"
 
 
 def test_add_correlation_id_filter():
@@ -44,11 +45,11 @@ def test_add_correlation_id_filter():
     test_record = logging.LogRecord(
         name=EXAMPLE_ORIGINATOR,
         level=logging.INFO,
-        pathname='./some/path/to/file.py',
+        pathname="./some/path/to/file.py",
         lineno=123,
-        msg='hello world',
+        msg="hello world",
         args=None,
-        exc_info=(None, None, None)
+        exc_info=(None, None, None),
     )
 
     # corr_id does not exist yet, so filter fails
@@ -64,25 +65,27 @@ def test_set_corr_id():
 
     expected_result = [EXAMPLE_ORIGINATOR, str(EXAMPLE_UUID), EXAMPLE_ISSUE_STR]
     assert get_corr_id_context_var_parts() == expected_result
-    assert get_corr_id_context_var_str() == ';'.join(expected_result)
+    assert get_corr_id_context_var_str() == ";".join(expected_result)
 
 
 def test_set_corr_id_datetime():
     set_corr_id_context_var(EXAMPLE_ORIGINATOR, key=EXAMPLE_UUID, issue_dt=EXAMPLE_ISSUE_DT)
 
     assert get_corr_id_context_var_parts() == [
-        EXAMPLE_ORIGINATOR, str(EXAMPLE_UUID), EXAMPLE_ISSUE_STR
+        EXAMPLE_ORIGINATOR,
+        str(EXAMPLE_UUID),
+        EXAMPLE_ISSUE_STR,
     ]
 
 
 def test_get_default_log_config_with_corr_id(capsys):
-    logging.config.dictConfig(get_default_log_config('INFO'))
+    logging.config.dictConfig(get_default_log_config("INFO"))
     corr_id = get_corr_id_context_var_str()
 
     logger.debug(msg=EXAMPLE_LOG_MESSAGE)
     stdout = capsys.readouterr().out  # capture std output from test run
     # should not be logging DEBUG if default log config handled level correctly
-    assert stdout == ''
+    assert stdout == ""
 
     logger.info(msg=EXAMPLE_LOG_MESSAGE)
     stdout = capsys.readouterr().out
@@ -91,16 +94,16 @@ def test_get_default_log_config_with_corr_id(capsys):
 
 
 def test_get_default_log_config_no_corr_id(capsys):
-    logging.config.dictConfigClass(get_default_log_config('DEBUG', False))
+    logging.config.dictConfigClass(get_default_log_config("DEBUG", False))
     corr_id = get_corr_id_context_var_str()
 
-    logger.debug('hello world')
+    logger.debug("hello world")
     stdout = capsys.readouterr().out
     assert corr_id not in stdout
 
 
 def test_getting_logs_from_threaded_func(capsys):
-    logging.config.dictConfig(get_default_log_config('INFO', True))
+    logging.config.dictConfig(get_default_log_config("INFO", True))
     set_corr_id_context_var(EXAMPLE_ORIGINATOR, key=EXAMPLE_UUID)
 
     def worker():
@@ -111,13 +114,13 @@ def test_getting_logs_from_threaded_func(capsys):
     thread = threading.Thread(target=contextvars.copy_context().run, args=(worker,))
     thread.start()
 
-    time.sleep(.1)
+    time.sleep(0.1)
     stdout = capsys.readouterr().out
     assert EXAMPLE_LOG_MESSAGE in stdout
 
 
 def test_getting_logs_from_thread_class(capsys):
-    logging.config.dictConfig(get_default_log_config('INFO', True))
+    logging.config.dictConfig(get_default_log_config("INFO", True))
     set_corr_id_context_var(EXAMPLE_ORIGINATOR, key=EXAMPLE_UUID)
 
     def set_context(context):
@@ -131,7 +134,7 @@ def test_getting_logs_from_thread_class(capsys):
 
         def run(self):
             set_context(self.context)
-            logger = logging.getLogger(f'{__name__}::{self.__class__.__name__}')
+            logger = logging.getLogger(f"{__name__}::{self.__class__.__name__}")
             logger.info(EXAMPLE_LOG_MESSAGE)
 
     thread = MyThread()

--- a/python/idsse_common/test/test_path_builder.py
+++ b/python/idsse_common/test/test_path_builder.py
@@ -1,4 +1,5 @@
 """Test suite for path_builder.py"""
+
 # --------------------------------------------------------------------------------
 # Created on Thu Jun 15 2023
 #
@@ -16,15 +17,15 @@ from pytest import fixture, raises
 from idsse.common.path_builder import TimeDelta, PathBuilder
 
 # properties
-EXAMPLE_BASE_DIR = './some/directory'
-EXAMPLE_SUB_DIR = 'another/directory'
-EXAMPLE_FILE = 'my_file'
-EXAMPLE_FILE_EXT = '.txt'
+EXAMPLE_BASE_DIR = "./some/directory"
+EXAMPLE_SUB_DIR = "another/directory"
+EXAMPLE_FILE = "my_file"
+EXAMPLE_FILE_EXT = ".txt"
 
 EXAMPLE_ISSUE = datetime(1970, 10, 3, 12, tzinfo=UTC)  # a.k.a. issued at
 EXAMPLE_VALID = datetime(1970, 10, 3, 14, tzinfo=UTC)  # a.k.a. valid until
 EXAMPLE_LEAD = TimeDelta(EXAMPLE_VALID - EXAMPLE_ISSUE)  # a.k.a. duration of time that issue lasts
-EXAMPLE_FULL_PATH = '~/blend.19701003/12/core/blend.t12z.core.f002.co.grib2.idx'
+EXAMPLE_FULL_PATH = "~/blend.19701003/12/core/blend.t12z.core.f002.co.grib2.idx"
 
 
 @fixture
@@ -36,47 +37,47 @@ def local_path_builder() -> PathBuilder:
 @fixture
 def path_builder() -> PathBuilder:
     subdirectory_pattern = (
-        'blend.{issue.year:04d}{issue.month:02d}{issue.day:02d}/{issue.hour:02d}/core/'
+        "blend.{issue.year:04d}{issue.month:02d}{issue.day:02d}/{issue.hour:02d}/core/"
     )
-    file_base_pattern = 'blend.t{issue.hour:02d}z.core.f{lead.hour:03d}.co'
-    return PathBuilder('~', subdirectory_pattern, file_base_pattern, 'grib2.idx')
+    file_base_pattern = "blend.t{issue.hour:02d}z.core.f{lead.hour:03d}.co"
+    return PathBuilder("~", subdirectory_pattern, file_base_pattern, "grib2.idx")
 
 
 @fixture
 def path_builder_with_region() -> PathBuilder:
     subdirectory_pattern = (
-        'blend.{issue.year:04d}{issue.month:02d}{issue.day:02d}/{issue.hour:02d}/core/'
+        "blend.{issue.year:04d}{issue.month:02d}{issue.day:02d}/{issue.hour:02d}/core/"
     )
-    file_base_pattern = 'blend.t{issue.hour:02d}z.core.f{lead.hour:03d}.{region:2s}'
-    return PathBuilder('~', subdirectory_pattern, file_base_pattern, 'grib2.idx')
+    file_base_pattern = "blend.t{issue.hour:02d}z.core.f{lead.hour:03d}.{region:2s}"
+    return PathBuilder("~", subdirectory_pattern, file_base_pattern, "grib2.idx")
 
 
 def test_from_dir_filename_creates_valid_path_builder():
-    directory = './test_directory'
-    filename = 'some_file.txt'
+    directory = "./test_directory"
+    filename = "some_file.txt"
     path_builder = PathBuilder.from_dir_filename(directory, filename)
 
     assert isinstance(path_builder, PathBuilder)
     assert path_builder.base_dir == directory
-    assert path_builder.file_ext == '.txt'
+    assert path_builder.file_ext == ".txt"
 
 
 def test_from_path_creates_valid_path_builder():
-    base_dir = './test_directory'
-    filename = 'some_file.txt'
-    path_builder = PathBuilder.from_path(f'{base_dir}/{filename}')
+    base_dir = "./test_directory"
+    filename = "some_file.txt"
+    path_builder = PathBuilder.from_path(f"{base_dir}/{filename}")
     assert isinstance(path_builder, PathBuilder)
     assert path_builder.base_dir == base_dir
     assert path_builder.file_base == filename
-    assert path_builder.file_ext == '.txt'
+    assert path_builder.file_ext == ".txt"
 
 
 def test_dir_fmt(local_path_builder: PathBuilder):
-    assert local_path_builder.dir_fmt == f'{EXAMPLE_BASE_DIR}/{EXAMPLE_SUB_DIR}'
+    assert local_path_builder.dir_fmt == f"{EXAMPLE_BASE_DIR}/{EXAMPLE_SUB_DIR}"
 
 
 def test_filename_fmt(local_path_builder: PathBuilder):
-    assert local_path_builder.filename_fmt == f'{EXAMPLE_FILE}{EXAMPLE_FILE_EXT}'
+    assert local_path_builder.filename_fmt == f"{EXAMPLE_FILE}{EXAMPLE_FILE_EXT}"
 
 
 def test_file_ext(local_path_builder: PathBuilder):
@@ -85,13 +86,13 @@ def test_file_ext(local_path_builder: PathBuilder):
 
 def test_path_fmt(local_path_builder: PathBuilder):
     assert local_path_builder.path_fmt == (
-        f'{EXAMPLE_BASE_DIR}/{EXAMPLE_SUB_DIR}/{EXAMPLE_FILE}{EXAMPLE_FILE_EXT}'
+        f"{EXAMPLE_BASE_DIR}/{EXAMPLE_SUB_DIR}/{EXAMPLE_FILE}{EXAMPLE_FILE_EXT}"
     )
 
 
 def test_build_dir_gets_issue_valid_and_lead(path_builder: PathBuilder):
     result = path_builder.build_dir(issue=EXAMPLE_ISSUE)
-    assert result == '~/blend.19701003/12/core/'
+    assert result == "~/blend.19701003/12/core/"
 
 
 def test_build_dir_fails_without_issue(path_builder: PathBuilder):
@@ -101,38 +102,35 @@ def test_build_dir_fails_without_issue(path_builder: PathBuilder):
 
 def test_build_filename(path_builder: PathBuilder):
     result_filename = path_builder.build_filename(issue=EXAMPLE_ISSUE, lead=EXAMPLE_LEAD)
-    assert result_filename == 'blend.t12z.core.f002.co.grib2.idx'
+    assert result_filename == "blend.t12z.core.f002.co.grib2.idx"
 
 
 def test_build_path(path_builder: PathBuilder):
     result_filepath = path_builder.build_path(issue=EXAMPLE_ISSUE, valid=EXAMPLE_VALID)
-    assert result_filepath == '~/blend.19701003/12/core/blend.t12z.core.f002.co.grib2.idx'
+    assert result_filepath == "~/blend.19701003/12/core/blend.t12z.core.f002.co.grib2.idx"
 
 
 def test_build_path_with_invalid_lead(path_builder: PathBuilder):
     # if lead needs more than 3 chars to be represented, ValueError will be raised
     with raises(ValueError):
-        path_builder.build_path(issue=EXAMPLE_ISSUE,
-                                lead=EXAMPLE_LEAD*1000)
+        path_builder.build_path(issue=EXAMPLE_ISSUE, lead=EXAMPLE_LEAD * 1000)
 
 
 def test_build_path_with_region(path_builder_with_region: PathBuilder):
-    region = 'co'
-    result = path_builder_with_region.build_path(issue=EXAMPLE_ISSUE,
-                                                 lead=EXAMPLE_LEAD,
-                                                 region=region)
+    region = "co"
+    result = path_builder_with_region.build_path(
+        issue=EXAMPLE_ISSUE, lead=EXAMPLE_LEAD, region=region
+    )
     result_dict = path_builder_with_region.parse_path(result)
-    assert result_dict['issue'] == EXAMPLE_ISSUE
-    assert result_dict['lead'] == EXAMPLE_LEAD
-    assert result_dict['region'] == region
+    assert result_dict["issue"] == EXAMPLE_ISSUE
+    assert result_dict["lead"] == EXAMPLE_LEAD
+    assert result_dict["region"] == region
 
 
 def test_build_path_with_invalid_region(path_builder_with_region: PathBuilder):
     # if region is more than 2 chars, ValueError will be raised
     with raises(ValueError):
-        path_builder_with_region.build_path(issue=EXAMPLE_ISSUE,
-                                            lead=EXAMPLE_LEAD,
-                                            region='conus')
+        path_builder_with_region.build_path(issue=EXAMPLE_ISSUE, lead=EXAMPLE_LEAD, region="conus")
 
 
 def test_build_path_with_required_but_missing_region(path_builder_with_region: PathBuilder):
@@ -145,14 +143,14 @@ def test_parse_dir(path_builder: PathBuilder):
     result_dict = path_builder.parse_dir(EXAMPLE_FULL_PATH)
 
     assert result_dict.keys() != []
-    assert result_dict['issue.year'] == 1970
-    assert result_dict['issue.day'] == 3
+    assert result_dict["issue.year"] == 1970
+    assert result_dict["issue.day"] == 3
 
 
 def test_parse_filename(path_builder: PathBuilder):
     result_dict = path_builder.parse_filename(EXAMPLE_FULL_PATH)
     assert result_dict.keys() != []
-    assert result_dict['lead.hour'] == 2
+    assert result_dict["lead.hour"] == 2
 
 
 def test_get_issue(path_builder: PathBuilder):
@@ -168,7 +166,7 @@ def test_get_valid_from_issue_and_lead(path_builder: PathBuilder):
 
 
 def test_get_valid_returns_none_when_issue_or_lead_failed(path_builder: PathBuilder):
-    path_with_invalid_lead = '~/blend.19701003/12/core/blend.t12z.core.f000.co.grib2.idx'
+    path_with_invalid_lead = "~/blend.19701003/12/core/blend.t12z.core.f000.co.grib2.idx"
     result_valid = path_builder.get_valid(path_with_invalid_lead)
 
     assert result_valid is None

--- a/python/idsse_common/test/test_rabbitmq_rpc.py
+++ b/python/idsse_common/test/test_rabbitmq_rpc.py
@@ -1,4 +1,5 @@
 """Testing for RabbitMqUtils functions"""
+
 # ------------------------------------------------------------------------------
 # Created on Thu Feb 27 2025
 #
@@ -20,29 +21,39 @@ from pika import BasicProperties, BlockingConnection
 from pika.adapters.blocking_connection import BlockingChannel
 
 from idsse.common.rabbitmq_utils import DIRECT_REPLY_QUEUE, Queue
-from idsse.common.rabbitmq_rpc import (Conn, Consumer, Exch, Future, RabbitMqParams,
-                                       RabbitMqMessage, RpcConsumer, RpcPublisher, RpcResponse)
+from idsse.common.rabbitmq_rpc import (
+    Conn,
+    Consumer,
+    Exch,
+    Future,
+    RabbitMqParams,
+    RabbitMqMessage,
+    RpcConsumer,
+    RpcPublisher,
+    RpcResponse,
+)
 
 
 # Example data objects
-CONN = Conn('localhost', '/', port=5672, username='user', password='password')
+CONN = Conn("localhost", "/", port=5672, username="user", password="password")
 RMQ_PARAMS = RabbitMqParams(
-    Exch('test_criteria_exch', 'topic'),
-    Queue('test_criteria_queue', '', True, False, True)
+    Exch("test_criteria_exch", "topic"), Queue("test_criteria_queue", "", True, False, True)
 )
-EXAMPLE_UUID = 'b6591cc7-8b33-4cd3-aa22-408c83ac5e3c'
+EXAMPLE_UUID = "b6591cc7-8b33-4cd3-aa22-408c83ac5e3c"
 
 
 class Method(NamedTuple):
     """Mock of pika.frame.Method"""
-    exchange: str = ' '
-    queue: str = ''
+
+    exchange: str = " "
+    queue: str = ""
     delivery_tag: int = 0
-    routing_key: str = ''
+    routing_key: str = ""
 
 
 class Frame(NamedTuple):
     """Mock of pika.frame.Frame"""
+
     method: Method
 
 
@@ -50,12 +61,14 @@ class Frame(NamedTuple):
 @fixture
 def mock_channel() -> Mock:
     """Mock pika.adapters.blocking_connection.BlockingChannel object"""
+
     def mock_queue_declare(queue: str, **_kwargs) -> Method:
         return Frame(Method(queue=queue))  # create a usable (mock) Frame using queue name passed
+
     def mock_exch_declare(exchange: str, **_kwargs) -> Method:
         return Frame(Method(exchange=exchange))
 
-    mock_obj = Mock(spec=BlockingChannel, name='MockChannel')
+    mock_obj = Mock(spec=BlockingChannel, name="MockChannel")
     mock_obj.exchange_declare = Mock(side_effect=mock_exch_declare)
     mock_obj.queue_declare = Mock(side_effect=mock_queue_declare)
     mock_obj.is_open = True
@@ -65,7 +78,7 @@ def mock_channel() -> Mock:
 @fixture
 def mock_connection(mock_channel: Mock) -> Mock:
     """Mock pika.BlockingChannel object"""
-    mock_obj = Mock(spec=BlockingConnection, name='MockConnection')
+    mock_obj = Mock(spec=BlockingConnection, name="MockConnection")
     mock_obj.channel = Mock(return_value=mock_channel)
     return mock_obj
 
@@ -73,7 +86,7 @@ def mock_connection(mock_channel: Mock) -> Mock:
 @fixture
 def mock_consumer(monkeypatch: MonkeyPatch, mock_connection: Mock, mock_channel: Mock) -> Mock:
     """Mock rabbitmq_utils.Consumer thread instance"""
-    mock_obj = Mock(spec=Consumer, name='MockConsumer')
+    mock_obj = Mock(spec=Consumer, name="MockConsumer")
     mock_obj.return_value.is_alive = Mock(return_value=False)  # by default, thread not running
     mock_obj.return_value.connection = mock_connection
     mock_obj.return_value.channel = mock_channel
@@ -82,9 +95,9 @@ def mock_consumer(monkeypatch: MonkeyPatch, mock_connection: Mock, mock_channel:
         side_effect=lambda cb: cb()
     )
 
-    monkeypatch.setattr('idsse.common.rabbitmq_rpc.Consumer', mock_obj)
+    monkeypatch.setattr("idsse.common.rabbitmq_rpc.Consumer", mock_obj)
     # temporarily need to mock Consumer out of rabbitmq_utils as well, where deprecated Rpc is
-    monkeypatch.setattr('idsse.common.rabbitmq_utils.Consumer', mock_obj)
+    monkeypatch.setattr("idsse.common.rabbitmq_utils.Consumer", mock_obj)
     return mock_obj
 
 
@@ -94,7 +107,7 @@ def mock_uuid(monkeypatch: MonkeyPatch) -> Mock:
     mock_obj = Mock()
     mock_obj.UUID = Mock(side_effect=lambda: UUID(EXAMPLE_UUID))
     mock_obj.uuid4 = Mock(side_effect=lambda: EXAMPLE_UUID)
-    monkeypatch.setattr('idsse.common.rabbitmq_rpc.uuid', mock_obj)
+    monkeypatch.setattr("idsse.common.rabbitmq_rpc.uuid", mock_obj)
     return mock_obj
 
 
@@ -135,83 +148,88 @@ def test_stop_does_nothing_if_not_started(rpc_thread: RpcPublisher, mock_consume
     mock_consumer.return_value.start.assert_not_called()
 
 
-def test_send_request_works_without_calling_start(rpc_thread: RpcPublisher,
-                                                  mock_channel: Mock,
-                                                  mock_connection: Mock,
-                                                  mock_consumer: Mock,
-                                                  monkeypatch: MonkeyPatch):
-    example_message = {'value': 'hello world'}
+def test_send_request_works_without_calling_start(
+    rpc_thread: RpcPublisher,
+    mock_channel: Mock,
+    mock_connection: Mock,
+    mock_consumer: Mock,
+    monkeypatch: MonkeyPatch,
+):
+    example_message = {"value": "hello world"}
 
     # when client calls blocking_publish, manually invoke response callback with a faked message
     # from external service, simulating RMQ call/response
     def mock_blocking_publish(*_args, **_kwargs):
         # build mock message from imaginary external service
-        method = Method('', 123)
-        props = BasicProperties(content_type='application/json', headers={'rpc': EXAMPLE_UUID})
-        body = bytes(json.dumps(example_message), encoding='utf-8')
+        method = Method("", 123)
+        props = BasicProperties(content_type="application/json", headers={"rpc": EXAMPLE_UUID})
+        body = bytes(json.dumps(example_message), encoding="utf-8")
         rpc_thread._on_response(mock_channel, method, props, body)
 
-    monkeypatch.setattr('idsse.common.rabbitmq_rpc.blocking_publish',
-                        Mock(side_effect=mock_blocking_publish))
+    monkeypatch.setattr(
+        "idsse.common.rabbitmq_rpc.blocking_publish", Mock(side_effect=mock_blocking_publish)
+    )
 
-    result = rpc_thread.send_request(RabbitMqMessage(json.dumps({'fake': 'request message'})))
+    result = rpc_thread.send_request(RabbitMqMessage(json.dumps({"fake": "request message"})))
     assert json.loads(result.body) == example_message
 
 
-def test_send_request_times_out_if_no_response(mock_connection: Mock,
-                                               mock_consumer: Mock,
-                                               mock_uuid: Mock,
-                                               monkeypatch: MonkeyPatch):
+def test_send_request_times_out_if_no_response(
+    mock_connection: Mock, mock_consumer: Mock, mock_uuid: Mock, monkeypatch: MonkeyPatch
+):
     # create client with same parameters, except a very short timeout
     _thread = RpcPublisher(CONN, RMQ_PARAMS.exchange, timeout=0.01)
 
     # do nothing on message publish
-    monkeypatch.setattr('idsse.common.rabbitmq_rpc.blocking_publish',
-                        Mock(side_effect=lambda *_args, **_kwargs: None))
+    monkeypatch.setattr(
+        "idsse.common.rabbitmq_rpc.blocking_publish",
+        Mock(side_effect=lambda *_args, **_kwargs: None),
+    )
 
-    result = _thread.send_request(RabbitMqMessage(json.dumps({'data': 123})))
+    result = _thread.send_request(RabbitMqMessage(json.dumps({"data": 123})))
     assert EXAMPLE_UUID not in _thread._pending_requests  # request was cleaned up
     assert result is None
 
 
 def test_send_requests_returns_none_on_error(rpc_thread: RpcPublisher, mock_channel: Mock):
     # pylint: disable=too-many-arguments
-    def mock_basic_publish(exchange, routing_key, body, properties = None, mandatory = False):
+    def mock_basic_publish(exchange, routing_key, body, properties=None, mandatory=False):
         # cause exception for pending request Future
-        rpc_thread._pending_requests[EXAMPLE_UUID].set_exception(RuntimeError('Something broke'))
+        rpc_thread._pending_requests[EXAMPLE_UUID].set_exception(RuntimeError("Something broke"))
+
     mock_channel.basic_publish.side_effect = mock_basic_publish
 
-    result = rpc_thread.send_request(RabbitMqMessage({'data': 123}))
+    result = rpc_thread.send_request(RabbitMqMessage({"data": 123}))
 
     assert EXAMPLE_UUID not in rpc_thread._pending_requests  # request was cleaned up
     assert result is None
 
 
-def test_nacks_unrecognized_response(rpc_thread: RpcPublisher,
-                                     mock_connection: Mock,
-                                     mock_channel: Mock,
-                                     monkeypatch: MonkeyPatch):
-    rpc_thread._pending_requests = {'abcd': Future()}
+def test_nacks_unrecognized_response(
+    rpc_thread: RpcPublisher, mock_connection: Mock, mock_channel: Mock, monkeypatch: MonkeyPatch
+):
+    rpc_thread._pending_requests = {"abcd": Future()}
     delivery_tag = 123
-    props = BasicProperties(content_type='application/json', headers={'rpc': 'unknown_id'})
-    body = bytes(json.dumps({'data': 123}), encoding='utf-8')
+    props = BasicProperties(content_type="application/json", headers={"rpc": "unknown_id"})
+    body = bytes(json.dumps({"data": 123}), encoding="utf-8")
 
     rpc_thread._on_response(mock_channel, Method(delivery_tag=delivery_tag), props, body)
 
     # unregistered message was acked with no-op (nothing was done to pending requests)
     mock_channel.basic_ack.assert_called_with(delivery_tag=delivery_tag)
-    assert 'abcd' in rpc_thread._pending_requests
-    assert not rpc_thread._pending_requests['abcd'].done()
+    assert "abcd" in rpc_thread._pending_requests
+    assert not rpc_thread._pending_requests["abcd"].done()
 
 
 def test_send_request_preserves_props(rpc_thread: RpcPublisher, mock_channel: Mock):
     # pylint: disable=too-many-arguments
-    def mock_basic_publish(exchange, routing_key, body, properties = None, mandatory = False):
+    def mock_basic_publish(exchange, routing_key, body, properties=None, mandatory=False):
         # cause exception for pending request Future
-        rpc_thread._pending_requests[EXAMPLE_UUID].set_exception(RuntimeError('Something broke'))
+        rpc_thread._pending_requests[EXAMPLE_UUID].set_exception(RuntimeError("Something broke"))
+
     mock_channel.basic_publish.side_effect = mock_basic_publish
 
-    result = rpc_thread.send_request(RabbitMqMessage({'data': 123}))
+    result = rpc_thread.send_request(RabbitMqMessage({"data": 123}))
 
     assert EXAMPLE_UUID not in rpc_thread._pending_requests  # request was cleaned up
     assert result is None
@@ -231,42 +249,48 @@ def test_rpc_consumer_start_stop(mock_consumer: Mock):
 
 
 def test_rpc_consumer_on_message_ack(mock_channel: Mock, mock_consumer: Mock):
-    example_response = RabbitMqMessage('{"response": "bar"}',
-                                       BasicProperties(content_type='application/json',
-                                                       correlation_id='some-correlation-id'))
+    example_response = RabbitMqMessage(
+        '{"response": "bar"}',
+        BasicProperties(content_type="application/json", correlation_id="some-correlation-id"),
+    )
     mock_on_request = Mock(return_value=RpcResponse(example_response, ack=True))
     inbound_tag = 7
-    inbound_rpc_id = '123'
-    inbound_reply_to = f'{DIRECT_REPLY_QUEUE}.g1h2AA5yZXBseUA1NTQ3NDU0OQAWaZUAAAAAZ7FK9g=='
-    inbound_props = BasicProperties(content_type='text/html',
-                                    headers={'rpc': inbound_rpc_id},
-                                    reply_to=inbound_reply_to)
-    inbound_body = bytes('{"request": "foo"}', encoding='utf-8')
+    inbound_rpc_id = "123"
+    inbound_reply_to = f"{DIRECT_REPLY_QUEUE}.g1h2AA5yZXBseUA1NTQ3NDU0OQAWaZUAAAAAZ7FK9g=="
+    inbound_props = BasicProperties(
+        content_type="text/html", headers={"rpc": inbound_rpc_id}, reply_to=inbound_reply_to
+    )
+    inbound_body = bytes('{"request": "foo"}', encoding="utf-8")
     rpc_consumer = RpcConsumer(CONN, RMQ_PARAMS, mock_on_request)
 
-    rpc_consumer._on_message(mock_channel, Method('', '', inbound_tag), inbound_props, inbound_body)
+    rpc_consumer._on_message(
+        mock_channel, Method("", "", inbound_tag), inbound_props, inbound_body
+    )
 
     mock_channel.basic_ack.assert_called_once_with(inbound_tag)
     assert mock_channel.basic_publish.call_count == 1
     published_args = mock_channel.basic_publish.call_args[1]
-    assert published_args['body'] == example_response.body
-    assert published_args['properties'].reply_to == inbound_reply_to
-    assert published_args['properties'].content_type == 'application/json'
-    assert published_args['properties'].correlation_id == 'some-correlation-id'
-    assert published_args['properties'].headers['rpc'] == inbound_rpc_id
+    assert published_args["body"] == example_response.body
+    assert published_args["properties"].reply_to == inbound_reply_to
+    assert published_args["properties"].content_type == "application/json"
+    assert published_args["properties"].correlation_id == "some-correlation-id"
+    assert published_args["properties"].headers["rpc"] == inbound_rpc_id
 
 
 def test_rpc_consumer_on_message_nack(mock_channel: Mock, mock_consumer: Mock):
-    example_response = RabbitMqMessage('{"response": "bar"}',
-                                       BasicProperties(content_type='application/json'))
+    example_response = RabbitMqMessage(
+        '{"response": "bar"}', BasicProperties(content_type="application/json")
+    )
     mock_on_request = Mock(return_value=RpcResponse(example_response, ack=False, requeue=True))
     inbound_tag = 7
-    inbound_props = BasicProperties(content_type='application/json',
-                                    headers={'rpc': '123'},
-                                    reply_to=DIRECT_REPLY_QUEUE)
-    inbound_body = bytes('{"request": "foo"}', encoding='utf-8')
+    inbound_props = BasicProperties(
+        content_type="application/json", headers={"rpc": "123"}, reply_to=DIRECT_REPLY_QUEUE
+    )
+    inbound_body = bytes('{"request": "foo"}', encoding="utf-8")
     rpc_consumer = RpcConsumer(CONN, RMQ_PARAMS, mock_on_request)
 
-    rpc_consumer._on_message(mock_channel, Method('', '', inbound_tag), inbound_props, inbound_body)
+    rpc_consumer._on_message(
+        mock_channel, Method("", "", inbound_tag), inbound_props, inbound_body
+    )
 
     mock_channel.basic_nack.assert_called_once_with(inbound_tag, requeue=True)

--- a/python/idsse_common/test/test_rabbitmq_utils.py
+++ b/python/idsse_common/test/test_rabbitmq_utils.py
@@ -1,4 +1,5 @@
 """Testing for RabbitMqUtils functions"""
+
 # ------------------------------------------------------------------------------
 # Created on Wed Nov 8 2023
 #
@@ -20,31 +21,44 @@ from pika import BlockingConnection
 from pika.adapters.blocking_connection import BlockingChannel
 from pika.exceptions import UnroutableError
 
-from idsse.common.rabbitmq_utils import (Conn, Consumer, Exch, Queue, Publisher, RabbitMqParams,
-                                         RabbitMqParamsAndCallback, RabbitMqMessage,
-                                         subscribe_to_queue, _publish, _setup_exch_and_queue,
-                                         threadsafe_call, threadsafe_ack, threadsafe_nack)
+from idsse.common.rabbitmq_utils import (
+    Conn,
+    Consumer,
+    Exch,
+    Queue,
+    Publisher,
+    RabbitMqParams,
+    RabbitMqParamsAndCallback,
+    RabbitMqMessage,
+    subscribe_to_queue,
+    _publish,
+    _setup_exch_and_queue,
+    threadsafe_call,
+    threadsafe_ack,
+    threadsafe_nack,
+)
 
 
 # Example data objects
-CONN = Conn('localhost', '/', port=5672, username='user', password='password')
+CONN = Conn("localhost", "/", port=5672, username="user", password="password")
 RMQ_PARAMS = RabbitMqParams(
-    Exch('test_criteria_exch', 'topic'),
-    Queue('test_criteria_queue', '', True, False, True)
+    Exch("test_criteria_exch", "topic"), Queue("test_criteria_queue", "", True, False, True)
 )
-EXAMPLE_UUID = 'b6591cc7-8b33-4cd3-aa22-408c83ac5e3c'
+EXAMPLE_UUID = "b6591cc7-8b33-4cd3-aa22-408c83ac5e3c"
 
 
 class Method(NamedTuple):
     """Mock of pika.frame.Method"""
-    exchange: str = ' '
-    queue: str = ''
+
+    exchange: str = " "
+    queue: str = ""
     delivery_tag: int = 0
-    routing_key: str = ''
+    routing_key: str = ""
 
 
 class Frame(NamedTuple):
     """Mock of pika.frame.Frame"""
+
     method: Method
 
 
@@ -52,13 +66,14 @@ class Frame(NamedTuple):
 @fixture
 def mock_channel() -> Mock:
     """Mock pika.adapters.blocking_connection.BlockingChannel object"""
+
     def mock_queue_declare(queue: str, **_kwargs) -> Method:
         return Frame(Method(queue=queue))  # create a usable (mock) Frame using queue name passed
 
     def mock_exch_declare(exchange: str, **_kwargs) -> Method:
         return Frame(Method(exchange=exchange))
 
-    mock_obj = Mock(spec=BlockingChannel, name='MockChannel')
+    mock_obj = Mock(spec=BlockingChannel, name="MockChannel")
     mock_obj.exchange_declare = Mock(side_effect=mock_exch_declare)
     mock_obj.queue_declare = Mock(side_effect=mock_queue_declare)
     mock_obj.is_open = True
@@ -68,7 +83,7 @@ def mock_channel() -> Mock:
 @fixture
 def mock_connection(mock_channel: Mock) -> Mock:
     """Mock pika.BlockingChannel object"""
-    mock_obj = Mock(spec=BlockingConnection, name='MockConnection')
+    mock_obj = Mock(spec=BlockingConnection, name="MockConnection")
     mock_obj.channel = Mock(return_value=mock_channel)
     return mock_obj
 
@@ -76,7 +91,7 @@ def mock_connection(mock_channel: Mock) -> Mock:
 # tests
 def test_connection_params_works(monkeypatch: MonkeyPatch, mock_connection: Mock):
     mock_blocking_connection = Mock(return_value=mock_connection)
-    monkeypatch.setattr('idsse.common.rabbitmq_utils.BlockingConnection', mock_blocking_connection)
+    monkeypatch.setattr("idsse.common.rabbitmq_utils.BlockingConnection", mock_blocking_connection)
 
     # run method
     mock_callback_function = Mock()
@@ -102,34 +117,29 @@ def test_connection_params_works(monkeypatch: MonkeyPatch, mock_connection: Mock
         exclusive=RMQ_PARAMS.queue.exclusive,
         durable=RMQ_PARAMS.queue.durable,
         auto_delete=RMQ_PARAMS.queue.auto_delete,
-        arguments={}
+        arguments={},
     )
 
     _channel.queue_bind.assert_called_once_with(
-        RMQ_PARAMS.queue.name,
-        RMQ_PARAMS.exchange.name,
-        RMQ_PARAMS.queue.route_key
+        RMQ_PARAMS.queue.name, RMQ_PARAMS.exchange.name, RMQ_PARAMS.queue.route_key
     )
 
     # assert queue connected to message callback
     _channel.basic_consume.assert_called_once_with(
-        queue=RMQ_PARAMS.queue.name,
-        on_message_callback=mock_callback_function,
-        auto_ack=False
+        queue=RMQ_PARAMS.queue.name, on_message_callback=mock_callback_function, auto_ack=False
     )
 
 
 def test_private_queue_sets_ttl(monkeypatch: MonkeyPatch, mock_connection: Mock):
     mock_blocking_connection = Mock(return_value=mock_connection)
-    monkeypatch.setattr('idsse.common.rabbitmq_utils.BlockingConnection', mock_blocking_connection)
-    example_queue = Queue('_my_private_queue', 'route_key', True, False, True)
+    monkeypatch.setattr("idsse.common.rabbitmq_utils.BlockingConnection", mock_blocking_connection)
+    example_queue = Queue("_my_private_queue", "route_key", True, False, True)
 
     # run method
     mock_callback_function = Mock()
     _connection, _channel = subscribe_to_queue(
-        CONN,
-        RabbitMqParams(RMQ_PARAMS.exchange, example_queue),
-        mock_callback_function)
+        CONN, RabbitMqParams(RMQ_PARAMS.exchange, example_queue), mock_callback_function
+    )
 
     # assert correct (mocked) pika calls were made
     mock_blocking_connection.assert_called_once()
@@ -141,14 +151,14 @@ def test_private_queue_sets_ttl(monkeypatch: MonkeyPatch, mock_connection: Mock)
         exclusive=example_queue.exclusive,
         durable=example_queue.durable,
         auto_delete=example_queue.auto_delete,
-        arguments={'x-message-ttl': 10000}
+        arguments={"x-message-ttl": 10000},
     )
 
 
 def test_passing_connection_does_not_create_new(mock_connection: Mock, monkeypatch: MonkeyPatch):
-    mock_callback_function = Mock(name='on_message_callback')
+    mock_callback_function = Mock(name="on_message_callback")
     mock_blocking_connection = Mock(return_value=mock_connection)
-    monkeypatch.setattr('idsse.common.rabbitmq_utils.BlockingConnection', mock_blocking_connection)
+    monkeypatch.setattr("idsse.common.rabbitmq_utils.BlockingConnection", mock_blocking_connection)
 
     new_connection, new_channel = subscribe_to_queue(CONN, RMQ_PARAMS, mock_callback_function)
 
@@ -156,26 +166,25 @@ def test_passing_connection_does_not_create_new(mock_connection: Mock, monkeypat
     assert new_connection == mock_connection
     # confirm that all channel setup proceeds normally
     new_channel.basic_consume.assert_called_once_with(
-        queue=RMQ_PARAMS.queue.name,
-        on_message_callback=mock_callback_function,
-        auto_ack=False
+        queue=RMQ_PARAMS.queue.name, on_message_callback=mock_callback_function, auto_ack=False
     )
 
 
 def test_passing_unsupported_connection_type_fails():
     with raises(ValueError) as exc:
-        subscribe_to_queue('bad connection', RMQ_PARAMS, Mock(name='on_message_callback'))
+        subscribe_to_queue("bad connection", RMQ_PARAMS, Mock(name="on_message_callback"))
     assert exc is not None
 
 
 def test_direct_reply_does_not_declare_queue(monkeypatch: MonkeyPatch, mock_connection: Mock):
-    params = RabbitMqParams(Exch('test_criteria_exch', 'topic'),
-                            Queue('amq.rabbitmq.reply-to', '', True, False, True))
+    params = RabbitMqParams(
+        Exch("test_criteria_exch", "topic"), Queue("amq.rabbitmq.reply-to", "", True, False, True)
+    )
 
     mock_blocking_connection = Mock(return_value=mock_connection)
-    monkeypatch.setattr('idsse.common.rabbitmq_utils.BlockingConnection', mock_blocking_connection)
+    monkeypatch.setattr("idsse.common.rabbitmq_utils.BlockingConnection", mock_blocking_connection)
 
-    _, new_channel = subscribe_to_queue(CONN, params, Mock(name='mock_callback'))
+    _, new_channel = subscribe_to_queue(CONN, params, Mock(name="mock_callback"))
 
     # assert that built-in Direct Reply-to queue was not recreated (pika would fail)
     new_channel.queue_declare.assert_not_called()
@@ -183,13 +192,13 @@ def test_direct_reply_does_not_declare_queue(monkeypatch: MonkeyPatch, mock_conn
     new_channel.basic_consume.assert_called_once()
 
 
-def test_default_exchange_does_not_declare_exchange(monkeypatch: MonkeyPatch,
-                                                    mock_connection: Mock):
-    params = RabbitMqParams(Exch('', 'topic'),
-                            Queue('something', '', True, False, True))
+def test_default_exchange_does_not_declare_exchange(
+    monkeypatch: MonkeyPatch, mock_connection: Mock
+):
+    params = RabbitMqParams(Exch("", "topic"), Queue("something", "", True, False, True))
 
     mock_blocking_connection = Mock(return_value=mock_connection)
-    monkeypatch.setattr('idsse.common.rabbitmq_utils.BlockingConnection', mock_blocking_connection)
+    monkeypatch.setattr("idsse.common.rabbitmq_utils.BlockingConnection", mock_blocking_connection)
 
     _, new_channel = subscribe_to_queue(CONN, params, Mock())
 
@@ -202,10 +211,10 @@ def test_simple_publisher(monkeypatch: MonkeyPatch, mock_connection: Mock):
     # add mock to get Connection callback to invoke immediately
     mock_connection.add_callback_threadsafe = Mock(side_effect=lambda callback: callback())
     mock_blocking_connection = Mock(return_value=mock_connection)
-    monkeypatch.setattr('idsse.common.rabbitmq_utils.BlockingConnection', mock_blocking_connection)
+    monkeypatch.setattr("idsse.common.rabbitmq_utils.BlockingConnection", mock_blocking_connection)
 
     mock_threadsafe = Mock()
-    monkeypatch.setattr('idsse.common.rabbitmq_utils.threadsafe_call', mock_threadsafe)
+    monkeypatch.setattr("idsse.common.rabbitmq_utils.threadsafe_call", mock_threadsafe)
 
     publisher = Publisher(CONN, RMQ_PARAMS.exchange)
     mock_blocking_connection.assert_called_once()
@@ -213,89 +222,95 @@ def test_simple_publisher(monkeypatch: MonkeyPatch, mock_connection: Mock):
     _channel.assert_called_once()
     assert publisher.connection == mock_connection
 
-    publisher.publish({'data': 123})
-    assert 'Publisher.publish' in str(mock_threadsafe.call_args[0][1])
+    publisher.publish({"data": 123})
+    assert "Publisher.publish" in str(mock_threadsafe.call_args[0][1])
 
     publisher.stop()
-    assert 'MockChannel.close' in str(mock_threadsafe.call_args[0][1])
+    assert "MockChannel.close" in str(mock_threadsafe.call_args[0][1])
 
 
 @fixture
 def mock_conn_params():
-    return Conn(
-        host='localhost',
-        v_host='/',
-        port=5672,
-        username='guest',
-        password='guest'
-    )
+    return Conn(host="localhost", v_host="/", port=5672, username="guest", password="guest")
 
 
 @fixture
 def mock_rmq_params_and_callback():
     exchange = Exch(name="test_exchange", type="direct")
-    queue = Queue(name="test_queue",
-                  route_key="test_key",
-                  durable=True,
-                  exclusive=False,
-                  auto_delete=False)
+    queue = Queue(
+        name="test_queue", route_key="test_key", durable=True, exclusive=False, auto_delete=False
+    )
     params = RabbitMqParams(exchange=exchange, queue=queue)
     callback = MagicMock()
     return RabbitMqParamsAndCallback(params=params, callback=callback)
 
 
-@patch('idsse.common.rabbitmq_utils.BlockingConnection')
-@patch('idsse.common.rabbitmq_utils.ThreadPoolExecutor')
-def test_consumer_initialization(mock_executor, mock_blocking_connection, mock_conn_params,
-                                 mock_rmq_params_and_callback, mock_channel):
+@patch("idsse.common.rabbitmq_utils.BlockingConnection")
+@patch("idsse.common.rabbitmq_utils.ThreadPoolExecutor")
+def test_consumer_initialization(
+    mock_executor,
+    mock_blocking_connection,
+    mock_conn_params,
+    mock_rmq_params_and_callback,
+    mock_channel,
+):
     mock_blocking_connection.return_value.channel.return_value = mock_channel
     Consumer(conn_params=mock_conn_params, rmq_params_and_callbacks=mock_rmq_params_and_callback)
     mock_blocking_connection.assert_called_once_with(mock_conn_params.connection_parameters)
     mock_channel.basic_qos.assert_called_once_with(prefetch_count=1)
 
 
-@patch('idsse.common.rabbitmq_utils.BlockingConnection')
-@patch('idsse.common.rabbitmq_utils.ThreadPoolExecutor')
-def test_consumer_start(mock_executor, mock_blocking_connection, mock_conn_params,
-                        mock_rmq_params_and_callback, mock_channel):
+@patch("idsse.common.rabbitmq_utils.BlockingConnection")
+@patch("idsse.common.rabbitmq_utils.ThreadPoolExecutor")
+def test_consumer_start(
+    mock_executor,
+    mock_blocking_connection,
+    mock_conn_params,
+    mock_rmq_params_and_callback,
+    mock_channel,
+):
     mock_blocking_connection.return_value.channel.return_value = mock_channel
-    consumer = Consumer(conn_params=mock_conn_params,
-                        rmq_params_and_callbacks=mock_rmq_params_and_callback)
-    with patch.object(consumer.channel, 'start_consuming') as start_consuming:
+    consumer = Consumer(
+        conn_params=mock_conn_params, rmq_params_and_callbacks=mock_rmq_params_and_callback
+    )
+    with patch.object(consumer.channel, "start_consuming") as start_consuming:
         consumer.run()
         start_consuming.assert_called_once()
 
 
-@patch('idsse.common.rabbitmq_utils.BlockingConnection')
-@patch('idsse.common.rabbitmq_utils.ThreadPoolExecutor')
-def test_on_message(mock_executor, mock_blocking_connection, mock_conn_params,
-                    mock_rmq_params_and_callback, mock_channel):
+@patch("idsse.common.rabbitmq_utils.BlockingConnection")
+@patch("idsse.common.rabbitmq_utils.ThreadPoolExecutor")
+def test_on_message(
+    mock_executor,
+    mock_blocking_connection,
+    mock_conn_params,
+    mock_rmq_params_and_callback,
+    mock_channel,
+):
     mock_blocking_connection.return_value.channel.return_value = mock_channel
-    consumer = Consumer(conn_params=mock_conn_params,
-                        rmq_params_and_callbacks=mock_rmq_params_and_callback)
+    consumer = Consumer(
+        conn_params=mock_conn_params, rmq_params_and_callbacks=mock_rmq_params_and_callback
+    )
     mock_func = MagicMock()
     consumer._on_message(mock_channel, MagicMock(), MagicMock(), b"Test Message", func=mock_func)
-    mock_executor.return_value.submit.assert_called_once_with(consumer.context.run,
-                                                              mock_func,
-                                                              mock_channel,
-                                                              ANY,
-                                                              ANY,
-                                                              b"Test Message")
+    mock_executor.return_value.submit.assert_called_once_with(
+        consumer.context.run, mock_func, mock_channel, ANY, ANY, b"Test Message"
+    )
 
 
 @fixture
 def mock_message():
-    return MagicMock(name='RabbitMqMessage', spec=dict)
+    return MagicMock(name="RabbitMqMessage", spec=dict)
 
 
 @fixture
 def mock_queue():
-    return MagicMock(name='Queue', spec=dict)
+    return MagicMock(name="Queue", spec=dict)
 
 
 def test_publish_success(mock_channel, mock_queue):
     # Arrange
-    exch = Exch(name='test', type='topic', mandatory=True)
+    exch = Exch(name="test", type="topic", mandatory=True)
     RabbitMqMessage.route_key = None
     success_flag = [False]
     done_event = Event()
@@ -327,7 +342,7 @@ def test_publish_failure(mock_channel):
     mock_channel.basic_publish.side_effect = Exception("Publish error")
     success_flag = [False]
     done_event = Event()
-    exch = Exch(name='test', type='topic', route_key='test.route', mandatory=True)
+    exch = Exch(name="test", type="topic", route_key="test.route", mandatory=True)
 
     # Act & Assert
     with raises(Exception, match="Publish error"):
@@ -349,8 +364,8 @@ def test_publish_with_private_queue(mock_channel, mock_queue):
     mock_queue.auto_delete = True
     success_flag = [False]
     done_event = Event()
-    exch = Exch(name='test', type='topic', route_key='test.route', mandatory=False)
-    msg = RabbitMqMessage(body={'data': 123}, route_key='', properties=None)
+    exch = Exch(name="test", type="topic", route_key="test.route", mandatory=False)
+    msg = RabbitMqMessage(body={"data": 123}, route_key="", properties=None)
 
     # Act
     _publish(
@@ -372,8 +387,8 @@ def test_publish_unroutable_error(mock_channel, mock_message):
     mock_channel.basic_publish.side_effect = UnroutableError(mock_message)
     success_flag = [False]
     done_event = Event()
-    exch = Exch(name='test', type='topic', route_key='test.route')
-    msg = RabbitMqMessage(body={'data': 123}, route_key='', properties=None)
+    exch = Exch(name="test", type="topic", route_key="test.route")
+    msg = RabbitMqMessage(body={"data": 123}, route_key="", properties=None)
 
     # Act
     _publish(
@@ -392,11 +407,9 @@ def test_publish_unroutable_error(mock_channel, mock_message):
 def test_setup_exch_and_queue_with_default_exchange(mock_channel):
     """Test setup when using the default exchange (no exchange declaration or binding)."""
     exch = Exch(name="", type="direct")
-    queue = Queue(name="test_queue",
-                  route_key="test_key",
-                  durable=True,
-                  exclusive=False,
-                  auto_delete=False)
+    queue = Queue(
+        name="test_queue", route_key="test_key", durable=True, exclusive=False, auto_delete=False
+    )
 
     _setup_exch_and_queue(mock_channel, exch, queue)
     mock_channel.queue_bind.assert_not_called()
@@ -405,20 +418,16 @@ def test_setup_exch_and_queue_with_default_exchange(mock_channel):
 def test_setup_exch_and_queue_with_exchange(mock_channel):
     """Test setup with a named exchange and binding to a queue."""
     exch = Exch(name="test_exchange", type="direct")
-    queue = Queue(name="test_queue",
-                  route_key="test_key",
-                  durable=True,
-                  exclusive=False,
-                  auto_delete=False)
+    queue = Queue(
+        name="test_queue", route_key="test_key", durable=True, exclusive=False, auto_delete=False
+    )
 
-    with patch('idsse.common.rabbitmq_utils._setup_exch') as mock_setup_exch:
+    with patch("idsse.common.rabbitmq_utils._setup_exch") as mock_setup_exch:
         _setup_exch_and_queue(mock_channel, exch, queue)
 
         mock_setup_exch.assert_called_once_with(mock_channel, exch)
         mock_channel.queue_bind.assert_called_once_with(
-            "test_queue",
-            exchange="test_exchange",
-            routing_key="test_key"
+            "test_queue", exchange="test_exchange", routing_key="test_key"
         )
 
 
@@ -431,7 +440,7 @@ def test_setup_exch_and_queue_with_quorum_queue(mock_channel):
         durable=True,
         exclusive=False,
         auto_delete=True,
-        arguments={"x-queue-type": "quorum"}
+        arguments={"x-queue-type": "quorum"},
     )
 
     with raises(ValueError, match="Quorum queues can not be configured to auto delete"):
@@ -441,11 +450,13 @@ def test_setup_exch_and_queue_with_quorum_queue(mock_channel):
 def test_setup_exch_and_queue_direct_reply_to(mock_channel):
     """Test behavior with the Direct Reply-to queue."""
     exch = Exch(name="", type="direct")
-    queue = Queue(name="amq.rabbitmq.reply-to",
-                  route_key="test_key",
-                  durable=False,
-                  exclusive=True,
-                  auto_delete=False)
+    queue = Queue(
+        name="amq.rabbitmq.reply-to",
+        route_key="test_key",
+        durable=False,
+        exclusive=True,
+        auto_delete=False,
+    )
 
     _setup_exch_and_queue(mock_channel, exch, queue)
 

--- a/python/idsse_common/test/test_utils.py
+++ b/python/idsse_common/test/test_utils.py
@@ -1,4 +1,5 @@
 """Test suite for utils.py"""
+
 # --------------------------------------------------------------------------------
 # Created on Mon Mar 20 2023
 #
@@ -30,7 +31,7 @@ from idsse.common.utils import (
     round_,
     round_half_away,
     to_compact,
-    to_iso
+    to_iso,
 )
 
 
@@ -50,24 +51,24 @@ def test_timedelta_day():
 
 
 def test_map_dict_init_with_args():
-    example_dict = {'value': 123, 'metadata': { 'other_data': [100, 200]}}
+    example_dict = {"value": 123, "metadata": {"other_data": [100, 200]}}
     example_map = Map(example_dict)
 
     # pylint: disable=no-member
     assert example_map.value == 123
-    assert example_map.metadata == {'other_data': [100, 200]}
+    assert example_map.metadata == {"other_data": [100, 200]}
 
 
 def test_map_dict_init_with_kwargs():
-    example_map = Map(value=123, metadata={'other_data': [100, 200]})
+    example_map = Map(value=123, metadata={"other_data": [100, 200]})
 
     # pylint: disable=no-member
     assert example_map.value == 123
-    assert example_map.metadata == {'other_data': [100, 200]}
+    assert example_map.metadata == {"other_data": [100, 200]}
 
 
 def test_map_dict_set_value():
-    example_map = Map(value=123, metadata={'other_data': [100, 200]})
+    example_map = Map(value=123, metadata={"other_data": [100, 200]})
     example_map.value = 321  # change value
     # pylint: disable=no-member
     assert example_map.value == 321
@@ -75,49 +76,50 @@ def test_map_dict_set_value():
 
 def test_exec_cmd():
     current_dir = path.dirname(__file__)
-    result = exec_cmd(['ls', current_dir])
+    result = exec_cmd(["ls", current_dir])
 
     # verify that at least __init__ and this file were found
-    assert '__init__.py' in result
+    assert "__init__.py" in result
     assert __file__.split(path.sep, maxsplit=-1)[-1] in result
 
 
 def test_to_iso():
     dt = datetime(2013, 12, 11, 10, 9, 8)
-    assert to_iso(dt) == '2013-12-11T10:09:08.000Z'
+    assert to_iso(dt) == "2013-12-11T10:09:08.000Z"
 
 
 def test_to_compact():
     dt = datetime(2013, 12, 11, 10, 9, 8)
-    assert to_compact(dt) == '20131211100908'
+    assert to_compact(dt) == "20131211100908"
 
 
-@pytest.mark.parametrize('string, hash_code_', [('Everyone is equal', 1346529203),
-                                                ('You are awesome', -1357061130)])
+@pytest.mark.parametrize(
+    "string, hash_code_", [("Everyone is equal", 1346529203), ("You are awesome", -1357061130)]
+)
 def test_hash_code(string, hash_code_):
     assert hash_code(string) == hash_code_
 
 
 def test_dict_copy_with():
-    starting_dict = { 'value': 123, 'units': 'mph'}
+    starting_dict = {"value": 123, "units": "mph"}
     copied_dict = deepcopy(starting_dict)
 
     # run copy
     result = dict_copy_with(
-        copied_dict, source='speedometer', metadata={'some': ('other', 'data')}
+        copied_dict, source="speedometer", metadata={"some": ("other", "data")}
     )
 
     # original dict should be unchanged
     assert copied_dict == starting_dict
-    assert 'source' not in copied_dict
+    assert "source" not in copied_dict
 
     # starting values should exist in result
-    assert result['value'] == starting_dict['value']
-    assert result['units'] == starting_dict['units']
+    assert result["value"] == starting_dict["value"]
+    assert result["units"] == starting_dict["units"]
 
     # new values should also have been added to result
-    assert result['source'] == 'speedometer'
-    assert result['metadata'] == {'some': ('other', 'data')}
+    assert result["source"] == "speedometer"
+    assert result["metadata"] == {"some": ("other", "data")}
 
 
 def test_datetime_gen_forward():
@@ -126,11 +128,13 @@ def test_datetime_gen_forward():
     max_num = 5
 
     dts_found = list(datetime_gen(dt_start, time_delta, max_num=max_num))
-    assert dts_found == [datetime(2021, 1, 2, 3, 0),
-                         datetime(2021, 1, 2, 4, 0),
-                         datetime(2021, 1, 2, 5, 0),
-                         datetime(2021, 1, 2, 6, 0),
-                         datetime(2021, 1, 2, 7, 0)]
+    assert dts_found == [
+        datetime(2021, 1, 2, 3, 0),
+        datetime(2021, 1, 2, 4, 0),
+        datetime(2021, 1, 2, 5, 0),
+        datetime(2021, 1, 2, 6, 0),
+        datetime(2021, 1, 2, 7, 0),
+    ]
 
 
 def test_datetime_gen_backwards():
@@ -139,10 +143,12 @@ def test_datetime_gen_backwards():
     max_num = 4
 
     dts_found = list(datetime_gen(dt_start, time_delta, max_num=max_num))
-    assert dts_found == [datetime(2021, 1, 2, 3, 0),
-                         datetime(2021, 1, 1, 3, 0),
-                         datetime(2020, 12, 31, 3, 0),
-                         datetime(2020, 12, 30, 3, 0)]
+    assert dts_found == [
+        datetime(2021, 1, 2, 3, 0),
+        datetime(2021, 1, 1, 3, 0),
+        datetime(2020, 12, 31, 3, 0),
+        datetime(2020, 12, 30, 3, 0),
+    ]
 
 
 def test_datetime_gen_bound():
@@ -151,9 +157,11 @@ def test_datetime_gen_bound():
     dt_end = datetime(2021, 1, 30, 3)
 
     dts_found = list(datetime_gen(dt_start, time_delta, dt_end))
-    assert dts_found == [datetime(2021, 1, 2, 3, 0),
-                         datetime(2021, 1, 16, 3, 0),
-                         datetime(2021, 1, 30, 3, 0)]
+    assert dts_found == [
+        datetime(2021, 1, 2, 3, 0),
+        datetime(2021, 1, 16, 3, 0),
+        datetime(2021, 1, 30, 3, 0),
+    ]
 
 
 def test_datetime_gen_switch_time_delta_sign():
@@ -162,27 +170,30 @@ def test_datetime_gen_switch_time_delta_sign():
     dt_end = datetime(2021, 1, 30, 3)
 
     dts_found = list(dt_ for dt_ in datetime_gen(dt_start, time_delta, dt_end))
-    assert dts_found == [datetime(2021, 1, 2, 3, 0),
-                         datetime(2021, 1, 16, 3, 0),
-                         datetime(2021, 1, 30, 3, 0)]
+    assert dts_found == [
+        datetime(2021, 1, 2, 3, 0),
+        datetime(2021, 1, 16, 3, 0),
+        datetime(2021, 1, 30, 3, 0),
+    ]
 
 
-@pytest.mark.parametrize('number, expected', [(2.50000, 3), (-14.5000, -15), (3.49999, 3)])
+@pytest.mark.parametrize("number, expected", [(2.50000, 3), (-14.5000, -15), (3.49999, 3)])
 def test_round_half_away_int(number: float, expected: int):
     result = round_half_away(number)
     assert isinstance(result, int)
     assert result == expected
 
 
-@pytest.mark.parametrize('number, expected', [(9.5432, 9.5), (-0.8765, -0.9)])
+@pytest.mark.parametrize("number, expected", [(9.5432, 9.5), (-0.8765, -0.9)])
 def test_round_half_away_float(number: float, expected: float):
     result = round_half_away(number, precision=1)
     assert isinstance(result, float)
     assert result == expected
 
 
-@pytest.mark.parametrize('number, expected',
-                  [(100.987654321, 100.988), (-43.21098, -43.211), (pi, 3.142)])
+@pytest.mark.parametrize(
+    "number, expected", [(100.987654321, 100.988), (-43.21098, -43.211), (pi, 3.142)]
+)
 def test_round_half_away_with_precision(number: float, expected: float):
     result = round_half_away(number, precision=3)
     assert isinstance(result, float)
@@ -191,28 +202,28 @@ def test_round_half_away_with_precision(number: float, expected: float):
 
 def test_invalid_rounding_method_raises_error():
     with pytest.raises(ValueError) as exc:
-        round_(123.456, rounding='MAGIC')
-    assert 'MAGIC' in exc.value.args[0]
+        round_(123.456, rounding="MAGIC")
+    assert "MAGIC" in exc.value.args[0]
 
     with pytest.raises(ValueError) as exc:
         round_(123.456, rounding=None)
-    assert 'None' in exc.value.args[0]
+    assert "None" in exc.value.args[0]
 
 
 def test_is_valid_uuid_success():
-    assert is_valid_uuid('f848406c-44eb-491f-99df-d0461090425c')
-    assert is_valid_uuid('f848406c-44eb-491f-99df-d0461090425c', version=4)
-    assert is_valid_uuid('1d10609e-ba56-11ee-af51-fa605d1346b6', version=1)
+    assert is_valid_uuid("f848406c-44eb-491f-99df-d0461090425c")
+    assert is_valid_uuid("f848406c-44eb-491f-99df-d0461090425c", version=4)
+    assert is_valid_uuid("1d10609e-ba56-11ee-af51-fa605d1346b6", version=1)
 
 
 def test_is_valid_uuid_failure():
-    assert not is_valid_uuid('abc-def-ghi-jlk')  # badly-formed UUID
-    assert not is_valid_uuid('1d10609e-ba56-11ee-af51-fa605d1346b6', version=7)  # invalid version
+    assert not is_valid_uuid("abc-def-ghi-jlk")  # badly-formed UUID
+    assert not is_valid_uuid("1d10609e-ba56-11ee-af51-fa605d1346b6", version=7)  # invalid version
 
 
 @pytest.fixture
 def example_file():
-    return f'./tmp/{uuid4()}'
+    return f"./tmp/{uuid4()}"
 
 
 @pytest.fixture(autouse=True)
@@ -260,18 +271,18 @@ def test_lock_timeout(example_file):
 
 
 def test_lock_creates_parent_dir():
-    parent_dir_a = './foo'
-    parent_dir_b = 'bar'
-    file_to_download = f'{parent_dir_a}/{parent_dir_b}/baz.txt'
+    parent_dir_a = "./foo"
+    parent_dir_b = "bar"
+    file_to_download = f"{parent_dir_a}/{parent_dir_b}/baz.txt"
     assert not os.path.exists(parent_dir_a)
     lock = FileBasedLock(file_to_download, max_age=60)
 
     lock.acquire()  # acquire() will magically create all nested parent dirs for .lock
     assert lock.locked
-    assert os.path.exists(f'{parent_dir_a}/{parent_dir_b}')
+    assert os.path.exists(f"{parent_dir_a}/{parent_dir_b}")
 
     # clean up lock and temporary parent dirs created for the lock
     lock.release()
-    os.rmdir(f'{parent_dir_a}/{parent_dir_b}')
+    os.rmdir(f"{parent_dir_a}/{parent_dir_b}")
     os.rmdir(parent_dir_a)
     assert not os.path.exists(parent_dir_a)

--- a/python/idsse_common/test/test_validate_criteria_schema.py
+++ b/python/idsse_common/test/test_validate_criteria_schema.py
@@ -1,4 +1,5 @@
-'''Test suite for criteria message using validate_schema.py'''
+"""Test suite for criteria message using validate_schema.py"""
+
 # ----------------------------------------------------------------------------------
 # Created on Mon Nov 20 2023
 #
@@ -21,7 +22,7 @@ from idsse.common.validate_schema import get_validator
 
 @fixture
 def criteria_validator() -> Validator:
-    schema_name = 'criteria_schema'
+    schema_name = "criteria_schema"
     return get_validator(schema_name)
 
 
@@ -31,35 +32,28 @@ def simple_criteria_message() -> dict:
         "corrId": {
             "originator": "IDSSe",
             "uuid": "4899d220-beec-467b-a0e6-9d215b715b97",
-            "issueDt": "2022-11-11T14:00:00.000Z"
+            "issueDt": "2022-11-11T14:00:00.000Z",
         },
         "issueDt": "2022-11-11T14:00:00.000Z",
         "location": {
             "features": [
                 {
                     "type": "Feature",
-                    "properties": {
-                        "name": "Abq"
-                    },
+                    "properties": {"name": "Abq"},
                     "geometry": {
                         "type": "Point",
-                        "coordinates": [-106.62312540068922, 34.964261450738306]
-                    }
+                        "coordinates": [-106.62312540068922, 34.964261450738306],
+                    },
                 }
             ]
         },
-        "validDt": [
-            {
-                "start": "2022-11-12T00:00:00.000Z",
-                "end": "2022-11-12T00:00:00.000Z"
-            }
-        ],
+        "validDt": [{"start": "2022-11-12T00:00:00.000Z", "end": "2022-11-12T00:00:00.000Z"}],
         "conditions": [
             {
                 "name": "Above Freeze Temp",
                 "severity": "MODERATE",
                 "combined": "A",
-                "partsUsed": ["A"]
+                "partsUsed": ["A"],
             }
         ],
         "parts": [
@@ -67,31 +61,16 @@ def simple_criteria_message() -> dict:
                 "name": "A",
                 "duration": 0,
                 "arealPercentage": 0,
-                "product": {
-                    "fcst": [
-                        "NBM"
-                    ]
-                },
+                "product": {"fcst": ["NBM"]},
                 "field": "TEMPERATURE",
                 "units": "DEG F",
                 "region": "CONUS",
                 "relational": "GREATER THAN",
                 "thresh": 30,
-                "mapping": {
-                    "min": 0.0,
-                    "max": 75.0,
-                    "clip": "true"
-                }
+                "mapping": {"min": 0.0, "max": 75.0, "clip": "true"},
             }
         ],
-        "tags": {
-            "values": [
-            ],
-            "keyValues": {
-                "name": "Abq Temp",
-                "nwsOffice": "BOU"
-            }
-        }
+        "tags": {"values": [], "keyValues": {"name": "Abq Temp", "nwsOffice": "BOU"}},
     }
 
 
@@ -101,36 +80,28 @@ def criteria_message() -> dict:
         "corrId": {
             "originator": "IDSSe",
             "uuid": "4899d220-beec-467b-a0e6-9d215b715b97",
-            "issueDt": "2022-10-07T14:00:00.000Z"
+            "issueDt": "2022-10-07T14:00:00.000Z",
         },
         "issueDt": "2022-10-07T14:00:00.000Z",
         "location": {
             "features": [
                 {
                     "type": "Feature",
-                    "properties": {
-                        "name": "The spot",
-                        "radius": 3.00
-                    },
+                    "properties": {"name": "The spot", "radius": 3.00},
                     "geometry": {
                         "type": "Point",
-                        "coordinates": [-106.62312540068922, 34.964261450738306]
-                    }
+                        "coordinates": [-106.62312540068922, 34.964261450738306],
+                    },
                 }
             ]
         },
-        "validDt": [
-            {
-                "start": "2022-10-08T0:00:00.000Z",
-                "end": "2022-10-08T12:00:00.000Z"
-            }
-        ],
+        "validDt": [{"start": "2022-10-08T0:00:00.000Z", "end": "2022-10-08T12:00:00.000Z"}],
         "conditions": [
             {
                 "name": "Two part Condition",
                 "severity": "MODERATE",
                 "combined": "A AND B",
-                "partsUsed": ["A", "B"]
+                "partsUsed": ["A", "B"],
             },
         ],
         "parts": [
@@ -138,94 +109,76 @@ def criteria_message() -> dict:
                 "name": "A",
                 "arealPercentage": 0,
                 "duration": 0,
-                "product": {
-                    "fcst": [
-                        "NBM"
-                    ]
-                },
+                "product": {"fcst": ["NBM"]},
                 "field": "DEW POINT",
                 "units": "Fahrenheit",
                 "region": "CONUS",
                 "relational": "LESS THAN",
                 "thresh": 60,
-                "mapping": {
-                    "min": 35.0,
-                    "max": 75.0,
-                    "clip": "true"
-                }
+                "mapping": {"min": 35.0, "max": 75.0, "clip": "true"},
             },
             {
                 "name": "B",
                 "arealPercentage": 0,
                 "duration": 0,
-                "product": {
-                    "fcst": [
-                        "NBM"
-                    ]
-                },
+                "product": {"fcst": ["NBM"]},
                 "field": "RELATIVE HUMIDITY",
                 "units": "PERCENT",
                 "region": "CONUS",
                 "relational": "GREATER THAN",
                 "thresh": 30,
-                "mapping": {
-                    "min": 0.0,
-                    "max": 75.0,
-                    "clip": "true"
-                }
-            }
+                "mapping": {"min": 0.0, "max": 75.0, "clip": "true"},
+            },
         ],
-        "tags": {
-            "values": [
-            ],
-            "keyValues": {
-                "name": "Abq Rain",
-                "nwsOffice": "BOU"
-            }
-        }
+        "tags": {"values": [], "keyValues": {"name": "Abq Rain", "nwsOffice": "BOU"}},
     }
 
 
-def test_validate_simple_criteria_message(criteria_validator: Validator,
-                                          simple_criteria_message: dict):
+def test_validate_simple_criteria_message(
+    criteria_validator: Validator, simple_criteria_message: dict
+):
     try:
         criteria_validator.validate(simple_criteria_message)
     except ValidationError as exc:
-        assert False, f'Validate message raised an exception {exc}'
+        assert False, f"Validate message raised an exception {exc}"
 
 
 def test_validate_criteria_message(criteria_validator: Validator, criteria_message: dict):
     try:
         criteria_validator.validate(criteria_message)
     except ValidationError as exc:
-        assert False, f'Validate message raised an exception {exc}'
+        assert False, f"Validate message raised an exception {exc}"
 
 
-def test_validate_criteria_message_without_conditions(criteria_validator: Validator,
-                                                      criteria_message: dict):
-    criteria_message.pop('conditions')
+def test_validate_criteria_message_without_conditions(
+    criteria_validator: Validator, criteria_message: dict
+):
+    criteria_message.pop("conditions")
     with raises(ValidationError):
         criteria_validator.validate(criteria_message)
 
 
-def test_validate_criteria_message_with_missing_name(criteria_validator: Validator,
-                                                     criteria_message: dict):
-    criteria_message['tags']['keyValues'].pop('name')
+def test_validate_criteria_message_with_missing_name(
+    criteria_validator: Validator, criteria_message: dict
+):
+    criteria_message["tags"]["keyValues"].pop("name")
     with raises(ValidationError):
         criteria_validator.validate(criteria_message)
 
 
-def test_validate_criteria_message_with_bad_product_type(criteria_validator: Validator,
-                                                         criteria_message: dict):
-    product = criteria_message['parts'][0]['product']
-    product['not_fcst_or_obs'] = product.pop('fcst')
+def test_validate_criteria_message_with_bad_product_type(
+    criteria_validator: Validator, criteria_message: dict
+):
+    product = criteria_message["parts"][0]["product"]
+    product["not_fcst_or_obs"] = product.pop("fcst")
     with raises(ValidationError):
         criteria_validator.validate(criteria_message)
 
 
-def test_validate_criteria_message_with_bad_mapping(criteria_validator: Validator,
-                                                    criteria_message: dict):
-    mapping = criteria_message['parts'][1]['mapping']
-    mapping['smallest'] = mapping.pop('min')
+def test_validate_criteria_message_with_bad_mapping(
+    criteria_validator: Validator, criteria_message: dict
+):
+    mapping = criteria_message["parts"][1]["mapping"]
+    mapping["smallest"] = mapping.pop("min")
     with raises(ValidationError):
         criteria_validator.validate(criteria_message)

--- a/python/idsse_common/test/test_validate_das_schema.py
+++ b/python/idsse_common/test/test_validate_das_schema.py
@@ -1,4 +1,5 @@
-'''Test suite for DAS messages using validate_schema.py'''
+"""Test suite for DAS messages using validate_schema.py"""
+
 # ----------------------------------------------------------------------------------
 # Created on Mon Nov 20 2023
 #
@@ -21,204 +22,247 @@ from idsse.common.validate_schema import get_validator
 
 @fixture
 def info_request_validator() -> Validator:
-    schema_name = 'das_info_request_schema'
+    schema_name = "das_info_request_schema"
     return get_validator(schema_name)
 
 
 @fixture
 def data_request_validator() -> Validator:
-    schema_name = 'das_data_request_schema'
+    schema_name = "das_data_request_schema"
     return get_validator(schema_name)
 
 
 @fixture
 def data_response_validator() -> Validator:
-    schema_name = 'das_data_response_schema'
+    schema_name = "das_data_response_schema"
     return get_validator(schema_name)
 
 
 @fixture
 def das_data_message() -> dict:
     return {
-        'sourceType': 'join',
-        'sourceObj': {
-            'sources': [{
-                'sourceType': 'condition',
-                'sourceObj': {
-                    'mapping': {
-                        'endWeight': [0, 1, 0],
-                        'startWeight': [0, 1, 0],
-                        'controlPoints': ['-Infinity', 35, 75, 'Infinity']},
-                    'relational': 'LESSTHAN',
-                    'source': {
-                        'sourceType': 'units',
-                        'sourceObj': {
-                            'units': 'F',
-                            'source': {
-                                'sourceType': 'data',
-                                'sourceObj': {
-                                    'product': 'NBM',
-                                    'field': 'TEMP',
-                                    'region': 'CONUS',
-                                    'valid': '2022-11-12T00:00:00.000Z',
-                                    'issue': '2022-11-11T14:00:00.000Z'}}},
-                        'label': 'NBM:TEMP:Fahrenheit'},
-                    'thresh': 60},
-                'label': 'NBM:TEMP:Fahrenheit:LT:60.000:35.000:75.000:true'},
+        "sourceType": "join",
+        "sourceObj": {
+            "sources": [
                 {
-                'sourceType': 'condition',
-                'sourceObj': {
-                    'mapping': {
-                        'endWeight': [0, 1, 0],
-                        'startWeight': [0, 1, 0],
-                        'controlPoints': ['-Infinity', 0, 5, 'Infinity']},
-                    'relational': 'GREATERTHAN',
-                    'source': {
-                        'sourceType': 'units',
-                        'sourceObj': {
-                            'units': 'MPH',
-                            'source': {
-                                'sourceType': 'data',
-                                'sourceObj': {
-                                    'product': 'NBM',
-                                    'field': 'WINDSPEED',
-                                    'region': 'CONUS',
-                                    'valid': '2022-11-12T00:00:00.000Z',
-                                    'issue': '2022-11-11T14:00:00.000Z'}}},
-                        'label': 'NBM:WINDSPEED:MilesPerHour'},
-                    'thresh': 3},
-                'label': 'NBM:WINDSPEED:MilesPerHour:GT:3.000:0.000:5.000:true'}],
-            'join': 'AND'},
-        'label': ('AND(NBM:TEMP:Fahrenheit:LT:60.000:35.000:75.000:true, '
-                  'NBM:WINDSPEED:MilesPerHour:GT:3.000:0.000:5.000:true)')
+                    "sourceType": "condition",
+                    "sourceObj": {
+                        "mapping": {
+                            "endWeight": [0, 1, 0],
+                            "startWeight": [0, 1, 0],
+                            "controlPoints": ["-Infinity", 35, 75, "Infinity"],
+                        },
+                        "relational": "LESSTHAN",
+                        "source": {
+                            "sourceType": "units",
+                            "sourceObj": {
+                                "units": "F",
+                                "source": {
+                                    "sourceType": "data",
+                                    "sourceObj": {
+                                        "product": "NBM",
+                                        "field": "TEMP",
+                                        "region": "CONUS",
+                                        "valid": "2022-11-12T00:00:00.000Z",
+                                        "issue": "2022-11-11T14:00:00.000Z",
+                                    },
+                                },
+                            },
+                            "label": "NBM:TEMP:Fahrenheit",
+                        },
+                        "thresh": 60,
+                    },
+                    "label": "NBM:TEMP:Fahrenheit:LT:60.000:35.000:75.000:true",
+                },
+                {
+                    "sourceType": "condition",
+                    "sourceObj": {
+                        "mapping": {
+                            "endWeight": [0, 1, 0],
+                            "startWeight": [0, 1, 0],
+                            "controlPoints": ["-Infinity", 0, 5, "Infinity"],
+                        },
+                        "relational": "GREATERTHAN",
+                        "source": {
+                            "sourceType": "units",
+                            "sourceObj": {
+                                "units": "MPH",
+                                "source": {
+                                    "sourceType": "data",
+                                    "sourceObj": {
+                                        "product": "NBM",
+                                        "field": "WINDSPEED",
+                                        "region": "CONUS",
+                                        "valid": "2022-11-12T00:00:00.000Z",
+                                        "issue": "2022-11-11T14:00:00.000Z",
+                                    },
+                                },
+                            },
+                            "label": "NBM:WINDSPEED:MilesPerHour",
+                        },
+                        "thresh": 3,
+                    },
+                    "label": "NBM:WINDSPEED:MilesPerHour:GT:3.000:0.000:5.000:true",
+                },
+            ],
+            "join": "AND",
+        },
+        "label": (
+            "AND(NBM:TEMP:Fahrenheit:LT:60.000:35.000:75.000:true, "
+            "NBM:WINDSPEED:MilesPerHour:GT:3.000:0.000:5.000:true)"
+        ),
     }
 
 
 # tests
 def test_validate_das_issue_request(info_request_validator: Validator):
-    message = {'sourceType': 'issue',
-               'sourceObj': {'product': 'NBM.AWS.GRIB',
-                             'region': 'PUERTO_RICO',
-                             'field': 'TEMP',
-                             }}
+    message = {
+        "sourceType": "issue",
+        "sourceObj": {
+            "product": "NBM.AWS.GRIB",
+            "region": "PUERTO_RICO",
+            "field": "TEMP",
+        },
+    }
     try:
         info_request_validator.validate(message)
     except ValidationError as exc:
-        assert False, f'Validate message raised an exception {exc}'
+        assert False, f"Validate message raised an exception {exc}"
 
 
 def test_validate_das_bad_issue_request(info_request_validator: Validator):
     # message is missing 'region'
-    message = {'sourceType': 'field',
-               'sourceObj': {'product': 'NBM.AWS.GRIB',
-                             'field': 'TEMP',
-                             'valid': '2022-01-02T15:00:00.000Z'
-                             }}
+    message = {
+        "sourceType": "field",
+        "sourceObj": {
+            "product": "NBM.AWS.GRIB",
+            "field": "TEMP",
+            "valid": "2022-01-02T15:00:00.000Z",
+        },
+    }
     with raises(ValidationError):
         info_request_validator.validate(message)
 
 
 def test_validate_das_valid_request(info_request_validator: Validator):
-    message = {'sourceType': 'valid',
-               'sourceObj': {'product': 'NBM.AWS.GRIB',
-                             'region': 'PUERTO_RICO',
-                             'field': 'TEMP',
-                             'issue': '2022-01-02T12:00:00.000Z'
-                             }}
+    message = {
+        "sourceType": "valid",
+        "sourceObj": {
+            "product": "NBM.AWS.GRIB",
+            "region": "PUERTO_RICO",
+            "field": "TEMP",
+            "issue": "2022-01-02T12:00:00.000Z",
+        },
+    }
     try:
         info_request_validator.validate(message)
     except ValidationError as exc:
-        assert False, f'Validate message raised an exception {exc}'
+        assert False, f"Validate message raised an exception {exc}"
 
 
 def test_validate_das_bad_valid_request(info_request_validator: Validator):
     # message is missing 'field'
-    message = {'sourceType': 'valid',
-               'sourceObj': {'product': 'NBM.AWS.GRIB',
-                             'region': 'PUERTO_RICO',
-                             'issue': '2022-01-02T12:00:00.000Z'
-                             }}
+    message = {
+        "sourceType": "valid",
+        "sourceObj": {
+            "product": "NBM.AWS.GRIB",
+            "region": "PUERTO_RICO",
+            "issue": "2022-01-02T12:00:00.000Z",
+        },
+    }
     with raises(ValidationError):
         info_request_validator.validate(message)
 
 
 def test_validate_das_lead_request(info_request_validator: Validator):
-    message = {'sourceType': 'lead',
-               'sourceObj': {'product': 'NBM.AWS.GRIB',
-                             'region': 'PUERTO_RICO',
-                             'field': 'TEMP',
-                             'issue': '2022-01-02T12:00:00.000Z'
-                             }}
+    message = {
+        "sourceType": "lead",
+        "sourceObj": {
+            "product": "NBM.AWS.GRIB",
+            "region": "PUERTO_RICO",
+            "field": "TEMP",
+            "issue": "2022-01-02T12:00:00.000Z",
+        },
+    }
     try:
         info_request_validator.validate(message)
     except ValidationError as exc:
-        assert False, f'Validate message raised an exception {exc}'
+        assert False, f"Validate message raised an exception {exc}"
 
 
 def test_validate_das_bad_lead_request(info_request_validator: Validator):
     # message is missing 'product'
-    message = {'sourceType': 'valid',
-               'sourceObj': {'region': 'PUERTO_RICO',
-                             'field': 'TEMP',
-                             'issue': '2022-01-02T12:00:00.000Z'
-                             }}
+    message = {
+        "sourceType": "valid",
+        "sourceObj": {
+            "region": "PUERTO_RICO",
+            "field": "TEMP",
+            "issue": "2022-01-02T12:00:00.000Z",
+        },
+    }
     with raises(ValidationError):
         info_request_validator.validate(message)
 
 
 def test_validate_das_field_request(info_request_validator: Validator):
-    message = {'sourceType': 'field',
-               'sourceObj': {'product': 'NBM.AWS.GRIB',
-                             'region': 'PUERTO_RICO',
-                             'field': 'TEMP',
-                             'issue': '2022-01-02T12:00:00.000Z',
-                             'valid': '2022-01-02T15:00:00.000Z'
-                             }}
+    message = {
+        "sourceType": "field",
+        "sourceObj": {
+            "product": "NBM.AWS.GRIB",
+            "region": "PUERTO_RICO",
+            "field": "TEMP",
+            "issue": "2022-01-02T12:00:00.000Z",
+            "valid": "2022-01-02T15:00:00.000Z",
+        },
+    }
     try:
         info_request_validator.validate(message)
     except ValidationError as exc:
-        assert False, f'Validate message raised an exception {exc}'
+        assert False, f"Validate message raised an exception {exc}"
 
 
 def test_validate_das_bad_field_request(info_request_validator: Validator):
     # message is missing 'issue'
-    message = {'sourceType': 'field',
-               'sourceObj': {'product': 'NBM.AWS.GRIB',
-                             'region': 'PUERTO_RICO',
-                             'field': 'TEMP',
-                             'valid': '2022-01-02T15:00:00.000Z'
-                             }}
+    message = {
+        "sourceType": "field",
+        "sourceObj": {
+            "product": "NBM.AWS.GRIB",
+            "region": "PUERTO_RICO",
+            "field": "TEMP",
+            "valid": "2022-01-02T15:00:00.000Z",
+        },
+    }
     with raises(ValidationError):
         info_request_validator.validate(message)
 
 
 def test_validate_das_data_request(data_request_validator: Validator):
     message = {
-        'sourceType': 'data',
-        'sourceObj': {
-            'product': 'NBM',
-            'region': 'CONUS',
-            'field': 'WINDSPEED',
-            'valid': '2022-11-12T00:00:00.000Z',
-            'issue': '2022-11-11T14:00:00.000Z'
-        }
+        "sourceType": "data",
+        "sourceObj": {
+            "product": "NBM",
+            "region": "CONUS",
+            "field": "WINDSPEED",
+            "valid": "2022-11-12T00:00:00.000Z",
+            "issue": "2022-11-11T14:00:00.000Z",
+        },
     }
     try:
         data_request_validator.validate(message)
     except ValidationError as exc:
-        assert False, f'Validate message raised an exception {exc}'
+        assert False, f"Validate message raised an exception {exc}"
 
 
 def test_validate_das_bad_data_request(data_request_validator: Validator):
     # missing product
     message = {
-        'sourceType': 'data',
-        'sourceObj': {
-            'region': 'CONUS',
-            'field': 'WINDSPEED',
-            'valid': '2022-11-12T00:00:00.000Z',
-            'issue': '2022-11-11T14:00:00.000Z'
-        }
+        "sourceType": "data",
+        "sourceObj": {
+            "region": "CONUS",
+            "field": "WINDSPEED",
+            "valid": "2022-11-12T00:00:00.000Z",
+            "issue": "2022-11-11T14:00:00.000Z",
+        },
     }
     with raises(ValidationError):
         data_request_validator.validate(message)
@@ -227,63 +271,65 @@ def test_validate_das_bad_data_request(data_request_validator: Validator):
 def test_validate_das_opr_with_single_source_request(data_request_validator: Validator):
     # this is an example of a unit conversion operator, the operator itself is not be validated
     message = {
-        'sourceType': 'units',
-        'sourceObj': {
-            'units': 'F',
-            'source': {
-                'sourceType': 'data',
-                'sourceObj': {
-                    'product': 'NBM.AWS.GRIB',
-                    'region': 'CONUS',
-                    'issue': '2022-01-02T12:00:00.000Z',
-                    'valid': '2022-01-02T15:00:00.000Z',
-                    'field': 'TEMP'
-                }
-            }
-        }
+        "sourceType": "units",
+        "sourceObj": {
+            "units": "F",
+            "source": {
+                "sourceType": "data",
+                "sourceObj": {
+                    "product": "NBM.AWS.GRIB",
+                    "region": "CONUS",
+                    "issue": "2022-01-02T12:00:00.000Z",
+                    "valid": "2022-01-02T15:00:00.000Z",
+                    "field": "TEMP",
+                },
+            },
+        },
     }
     try:
         data_request_validator.validate(message)
     except ValidationError as exc:
-        assert False, f'Validate message raised an exception {exc}'
+        assert False, f"Validate message raised an exception {exc}"
 
 
 def test_validate_das_bad_opr_with_single_source_request(data_request_validator: Validator):
     # this is an example of a unit conversion operator, the operator itself is not validated
     message = {
-        'sourceType': 'units',
-        'sourceObj': {
-            'units': 'F',
-            'source': {
-                'sourceType': 'field',
-                'sourceObj': {
-                    'product': 'NBM.AWS.GRIB',
-                    'region': 'CONUS',
-                    'issue': '2022-01-02T12:00:00.000Z',
-                    'valid': '2022-01-02T15:00:00.000Z',
-                    'field': 'TEMP'
-                }
-            }
-        }
+        "sourceType": "units",
+        "sourceObj": {
+            "units": "F",
+            "source": {
+                "sourceType": "field",
+                "sourceObj": {
+                    "product": "NBM.AWS.GRIB",
+                    "region": "CONUS",
+                    "issue": "2022-01-02T12:00:00.000Z",
+                    "valid": "2022-01-02T15:00:00.000Z",
+                    "field": "TEMP",
+                },
+            },
+        },
     }
     with raises(ValidationError):
         data_request_validator.validate(message)
 
 
-def test_validate_das_opr_with_multi_sources_request(data_request_validator: Validator,
-                                                     das_data_message: dict):
+def test_validate_das_opr_with_multi_sources_request(
+    data_request_validator: Validator, das_data_message: dict
+):
     # this is an example of a logical join operator, the operator itself is not validated
     try:
         data_request_validator.validate(das_data_message)
     except ValidationError as exc:
-        assert False, f'Validate message raised an exception {exc}'
+        assert False, f"Validate message raised an exception {exc}"
 
 
-def test_validate_das_bad_opr_with_multi_sources_request(data_request_validator: Validator,
-                                                         das_data_message: dict):
+def test_validate_das_bad_opr_with_multi_sources_request(
+    data_request_validator: Validator, das_data_message: dict
+):
     # one of the operator object does not contains 'source', has 'not_source' instead
-    mapping_opr = das_data_message['sourceObj']['sources'][1]['sourceObj']
-    mapping_opr['not_source'] = mapping_opr.pop('source')
+    mapping_opr = das_data_message["sourceObj"]["sources"][1]["sourceObj"]
+    mapping_opr["not_source"] = mapping_opr.pop("source")
     with raises(ValidationError):
         data_request_validator.validate(das_data_message)
 
@@ -293,39 +339,42 @@ def test_validate_das_data_response(data_response_validator: Validator):
         "corrId": {
             "issueDt": "2023-01-10T08:00:00Z",
             "originator": "IDSSe",
-            "uuid": "53430eaa-1db4-4095-bf13-a26e45223d9a"
+            "uuid": "53430eaa-1db4-4095-bf13-a26e45223d9a",
         },
         "request": {
-            'sourceType': 'data',
-            'sourceObj': {
-                'product': 'NBM',
-                'region': 'CONUS',
-                'field': 'TEMP',
-                'valid': '2022-11-12T00:00:00.000Z',
-                'issue': '2022-11-11T14:00:00.000Z'
-            }
+            "sourceType": "data",
+            "sourceObj": {
+                "product": "NBM",
+                "region": "CONUS",
+                "field": "TEMP",
+                "valid": "2022-11-12T00:00:00.000Z",
+                "issue": "2022-11-11T14:00:00.000Z",
+            },
         },
         "data_requested": {
             "filenames": {
-                "Deterministic":
-                "/data/share/2023/01/10/NBM.AWS.GRIB/Criteria/Criteria/gridstore-1309066818.nc"
+                "Deterministic": (
+                    "/data/share/2023/01/10/NBM.AWS.GRIB/Criteria/Criteria/gridstore-1309066818.nc"
+                )
             },
             "issue_dt": "2023-01-10T08:00:00Z",
             "valid_dt": "2023-01-11T06:00:00Z",
             "proj_name": "NBM",
             "proj_spec": "+proj=lcc +lat_0=25.0 +lon_0=-95.0 +lat_1=25.0 +a=6371200",
-            "grid_spec": ("+dx=2539.703 +dy=2539.703 +w=100 +h=100 "
-                          "+lat_ll=41.05894633497196 +lon_ll=-106.02046021316575"),
+            "grid_spec": (
+                "+dx=2539.703 +dy=2539.703 +w=100 +h=100 "
+                "+lat_ll=41.05894633497196 +lon_ll=-106.02046021316575"
+            ),
             "data_prod": "NBM",
             "data_name": "TEMP",
             "data_loc": "",
             "units": "Fahrenheit",
             "region": "CONUS",
-            "slice": "slice"
-        }
+            "slice": "slice",
+        },
     }
 
     try:
         data_response_validator.validate(message)
     except ValidationError as exc:
-        assert False, f'Validate message raised an exception {exc}'
+        assert False, f"Validate message raised an exception {exc}"

--- a/python/idsse_common/test/test_validate_das_web_schema.py
+++ b/python/idsse_common/test/test_validate_das_web_schema.py
@@ -1,4 +1,5 @@
-'''Test suite for DAS web message using validate_schema.py'''
+"""Test suite for DAS web message using validate_schema.py"""
+
 # ----------------------------------------------------------------------------------
 # Created on Mon Nov 20 2023
 #
@@ -21,202 +22,178 @@ from idsse.common.validate_schema import get_validator
 
 @fixture
 def das_web_request_validator() -> Validator:
-    schema_name = 'das_web_request_schema'
+    schema_name = "das_web_request_schema"
     return get_validator(schema_name)
 
 
 @fixture
 def das_web_response_validator() -> Validator:
-    schema_name = 'das_web_response_schema'
+    schema_name = "das_web_response_schema"
     return get_validator(schema_name)
 
 
 @fixture
 def das_web_request_message() -> dict:
     return {
-        'issueDt': '2023-01-10T08:00:00.000Z',
-        'dataRequest': 'A AND B',
-        'parts': [
+        "issueDt": "2023-01-10T08:00:00.000Z",
+        "dataRequest": "A AND B",
+        "parts": [
             {
-                'name': 'A',
-                'duration': 0,
-                'arealPercentage': 0,
-                'product': 'NBM',
-                'field': 'WINDSPEED',
-                'units': 'MilesPerHour',
-                'region': 'CONUS',
-                'relational': 'GREATER THAN',
-                'thresh': 5,
-                'mapping': {
-                    'min': 0.0,
-                    'max': 20.0,
-                    'clip': 'true'
-                }
+                "name": "A",
+                "duration": 0,
+                "arealPercentage": 0,
+                "product": "NBM",
+                "field": "WINDSPEED",
+                "units": "MilesPerHour",
+                "region": "CONUS",
+                "relational": "GREATER THAN",
+                "thresh": 5,
+                "mapping": {"min": 0.0, "max": 20.0, "clip": "true"},
             },
             {
-                'name': 'B',
-                'duration': 0,
-                'arealPercentage': 0,
-                'product': 'NBM',
-                'field': 'TEMPERATURE',
-                'units': 'Fahrenheit',
-                'region': 'CONUS',
-                'relational': 'LESS THAN OR EQUAL',
-                'thresh': 30,
-                'mapping': {
-                    'min': 15.0,
-                    'max': 45.0,
-                    'clip': 'true'
-                }
-            }
+                "name": "B",
+                "duration": 0,
+                "arealPercentage": 0,
+                "product": "NBM",
+                "field": "TEMPERATURE",
+                "units": "Fahrenheit",
+                "region": "CONUS",
+                "relational": "LESS THAN OR EQUAL",
+                "thresh": 30,
+                "mapping": {"min": 15.0, "max": 45.0, "clip": "true"},
+            },
         ],
-        'valids': [
-            '2023-01-11T06:00:00.000Z',
-            '2023-01-11T07:00:00.000Z',
-            '2023-01-11T08:00:00.000Z',
-            '2023-01-11T09:00:00.000Z',
-            '2023-01-11T10:00:00.000Z',
-            '2023-01-11T11:00:00.000Z',
-            '2023-01-11T12:00:00.000Z',
-            '2023-01-11T13:00:00.000Z',
-            '2023-01-11T14:00:00.000Z',
-            '2023-01-11T15:00:00.000Z',
-            '2023-01-11T16:00:00.000Z',
-            '2023-01-11T17:00:00.000Z',
-            '2023-01-11T18:00:00.000Z'
+        "valids": [
+            "2023-01-11T06:00:00.000Z",
+            "2023-01-11T07:00:00.000Z",
+            "2023-01-11T08:00:00.000Z",
+            "2023-01-11T09:00:00.000Z",
+            "2023-01-11T10:00:00.000Z",
+            "2023-01-11T11:00:00.000Z",
+            "2023-01-11T12:00:00.000Z",
+            "2023-01-11T13:00:00.000Z",
+            "2023-01-11T14:00:00.000Z",
+            "2023-01-11T15:00:00.000Z",
+            "2023-01-11T16:00:00.000Z",
+            "2023-01-11T17:00:00.000Z",
+            "2023-01-11T18:00:00.000Z",
         ],
-        'bbox': {
-            'botLeft': [910, 829],
-            'topRight': [1010, 929]
-        }
+        "bbox": {"botLeft": [910, 829], "topRight": [1010, 929]},
     }
 
 
 @fixture
 def das_web_response_message() -> dict:
     return {
-        'issueDt': '2023-01-10T08:00:00.000Z',
-        'dataRequest': 'A',
-        'parts': [
+        "issueDt": "2023-01-10T08:00:00.000Z",
+        "dataRequest": "A",
+        "parts": [
             {
-                'name': 'A',
-                'duration': 0,
-                'arealPercentage': 0,
-                'product': 'NBM',
-                'field': 'WINDSPEED',
-                'units': 'MilesPerHour',
-                'region': 'CONUS',
-                'relational': 'GREATER THAN',
-                'thresh': 5,
-                'mapping': {
-                    'min': 0.0,
-                    'max': 20.0,
-                    'clip': 'true'
-                }
+                "name": "A",
+                "duration": 0,
+                "arealPercentage": 0,
+                "product": "NBM",
+                "field": "WINDSPEED",
+                "units": "MilesPerHour",
+                "region": "CONUS",
+                "relational": "GREATER THAN",
+                "thresh": 5,
+                "mapping": {"min": 0.0, "max": 20.0, "clip": "true"},
             }
         ],
-        'valids': [
-            '2023-01-11T06:00:00.000Z',
-            '2023-01-11T18:00:00.000Z'
-        ],
-        'bbox': {
-            'botLeft': [100, 102],
-            'topRight': [200, 202]
+        "valids": ["2023-01-11T06:00:00.000Z", "2023-01-11T18:00:00.000Z"],
+        "bbox": {"botLeft": [100, 102], "topRight": [200, 202]},
+        "data": {
+            "2023-01-11T06:00:00.000Z": [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+            "2023-01-11T18:00:00.000Z": [[9, 8, 7], [6, 5, 4], [3, 2, 1]],
+            "scale": 10,
         },
-        'data': {
-            '2023-01-11T06:00:00.000Z': [
-                [1, 2, 3],
-                [4, 5, 6],
-                [7, 8, 9]
-            ],
-            '2023-01-11T18:00:00.000Z': [
-                [9, 8, 7],
-                [6, 5, 4],
-                [3, 2, 1]
-            ],
-            'scale': 10
-        }
     }
 
 
-def test_validate_das_web_request_message(das_web_request_validator: Validator,
-                                          das_web_request_message: dict):
+def test_validate_das_web_request_message(
+    das_web_request_validator: Validator, das_web_request_message: dict
+):
     try:
         das_web_request_validator.validate(das_web_request_message)
     except ValidationError as exc:
-        assert False, f'Validate message raised an exception {exc}'
+        assert False, f"Validate message raised an exception {exc}"
 
 
-def test_validate_das_web_request_message_with_bbox_list(das_web_request_validator: Validator,
-                                                         das_web_request_message: dict):
-    bbox = das_web_request_message.pop('bbox')
-    das_web_request_message['bbox'] = [bbox['botLeft'], bbox['topRight']]
+def test_validate_das_web_request_message_with_bbox_list(
+    das_web_request_validator: Validator, das_web_request_message: dict
+):
+    bbox = das_web_request_message.pop("bbox")
+    das_web_request_message["bbox"] = [bbox["botLeft"], bbox["topRight"]]
     try:
         das_web_request_validator.validate(das_web_request_message)
     except ValidationError as exc:
-        assert False, f'Validate message raised an exception {exc}'
+        assert False, f"Validate message raised an exception {exc}"
 
 
-def test_validate_das_web_request_message_bad_bbox_list(das_web_request_validator: Validator,
-                                                        das_web_request_message: dict):
-    bbox = das_web_request_message.pop('bbox')
-    bot_left = bbox['botLeft']
-    top_right = bbox['topRight']
+def test_validate_das_web_request_message_bad_bbox_list(
+    das_web_request_validator: Validator, das_web_request_message: dict
+):
+    bbox = das_web_request_message.pop("bbox")
+    bot_left = bbox["botLeft"]
+    top_right = bbox["topRight"]
     # move one value from bottom  and adding to top, making neither represent a coordinate
     top_right.append(bot_left.pop(1))
-    das_web_request_message['bbox'] = [bot_left, top_right]
+    das_web_request_message["bbox"] = [bot_left, top_right]
     with raises(ValidationError):
         das_web_request_validator.validate(das_web_request_message)
 
 
-def test_validate_das_web_request_message_bad_bbox_obj(das_web_request_validator: Validator,
-                                                       das_web_request_message: dict):
+def test_validate_das_web_request_message_bad_bbox_obj(
+    das_web_request_validator: Validator, das_web_request_message: dict
+):
     # replace the bottom left int coordinate with a float
-    das_web_request_message['bbox']['botLeft'][0] = 1.2
+    das_web_request_message["bbox"]["botLeft"][0] = 1.2
     with raises(ValidationError):
         das_web_request_validator.validate(das_web_request_message)
 
 
-def test_validate_das_web_request_message_multi_product(das_web_request_validator: Validator,
-                                                        das_web_request_message: dict):
+def test_validate_das_web_request_message_multi_product(
+    das_web_request_validator: Validator, das_web_request_message: dict
+):
     # replace the single product with multiple product structure (like in criteria and eventPort)
-    das_web_request_message['parts'][0]['product'] = {
-        'fcst': [
-            'NBM'
-        ]
-    }
+    das_web_request_message["parts"][0]["product"] = {"fcst": ["NBM"]}
     with raises(ValidationError):
         das_web_request_validator.validate(das_web_request_message)
 
 
-def test_validate_das_web_response_message(das_web_response_validator: Validator,
-                                           das_web_response_message: dict):
+def test_validate_das_web_response_message(
+    das_web_response_validator: Validator, das_web_response_message: dict
+):
     try:
         das_web_response_validator.validate(das_web_response_message)
     except ValidationError as exc:
-        assert False, f'Validate message raised an exception {exc}'
+        assert False, f"Validate message raised an exception {exc}"
 
 
-def test_validate_das_web_response_message_without_data(das_web_response_validator: Validator,
-                                                        das_web_response_message: dict):
+def test_validate_das_web_response_message_without_data(
+    das_web_response_validator: Validator, das_web_response_message: dict
+):
     # remove data
-    das_web_response_message.pop('data')
+    das_web_response_message.pop("data")
     with raises(ValidationError):
         das_web_response_validator.validate(das_web_response_message)
 
 
-def test_validate_das_web_response_message_bad_data_key(das_web_response_validator: Validator,
-                                                        das_web_response_message: dict):
+def test_validate_das_web_response_message_bad_data_key(
+    das_web_response_validator: Validator, das_web_response_message: dict
+):
     # add to data a key that is not scale, offset, datetime
-    das_web_response_message['data']['not scale/offset or datetime'] = 3
+    das_web_response_message["data"]["not scale/offset or datetime"] = 3
     with raises(ValidationError):
         das_web_response_validator.validate(das_web_response_message)
 
 
-def test_validate_das_web_response_message_bad_data(das_web_response_validator: Validator,
-                                                    das_web_response_message: dict):
+def test_validate_das_web_response_message_bad_data(
+    das_web_response_validator: Validator, das_web_response_message: dict
+):
     # add to data a key that is not scale, offset, datetime
-    validDt = das_web_response_message['valids'][0]
-    das_web_response_message['data'][validDt] = [['strings'], ['not', 'numbers']]
+    validDt = das_web_response_message["valids"][0]
+    das_web_response_message["data"][validDt] = [["strings"], ["not", "numbers"]]
     with raises(ValidationError):
         das_web_response_validator.validate(das_web_response_message)

--- a/python/idsse_common/test/test_validate_event_port_schema.py
+++ b/python/idsse_common/test/test_validate_event_port_schema.py
@@ -1,4 +1,5 @@
-'''Test suite for event port message using validate_schema.py'''
+"""Test suite for event port message using validate_schema.py"""
+
 # ----------------------------------------------------------------------------------
 # Created on Mon Nov 20 2023
 #
@@ -21,7 +22,7 @@ from idsse.common.validate_schema import get_validator
 
 @fixture
 def event_port_validator() -> Validator:
-    schema_name = 'event_portfolio_schema'
+    schema_name = "event_portfolio_schema"
     return get_validator(schema_name)
 
 
@@ -31,36 +32,24 @@ def simple_event_port_message() -> dict:
         "corrId": {
             "originator": "IDSSe",
             "uuid": "4899d220-beec-467b-a0e6-9d215b715b97",
-            "issueDt": "2022-11-11T14:00:00.000Z"
+            "issueDt": "2022-11-11T14:00:00.000Z",
         },
         "issueDt": "2022-11-11T14:00:00.000Z",
         "location": {
             "features": [
                 {
                     "type": "Feature",
-                    "properties": {
-                        "name": "Location 1"
-                    },
+                    "properties": {"name": "Location 1"},
                     "geometry": {
                         "type": "Point",
-                        "coordinates": [-106.62312540068922, 34.964261450738306]
-                    }
+                        "coordinates": [-106.62312540068922, 34.964261450738306],
+                    },
                 }
             ]
         },
-        "validDt": [
-            {
-                "start": "2022-11-12T00:00:00.000Z",
-                "end": "2022-11-12T00:00:00.000Z"
-            }
-        ],
+        "validDt": [{"start": "2022-11-12T00:00:00.000Z", "end": "2022-11-12T00:00:00.000Z"}],
         "conditions": [
-            {
-                "name": "Abq TEMP",
-                "severity": "MODERATE",
-                "combined": "A",
-                "partsUsed": ["A"]
-            }
+            {"name": "Abq TEMP", "severity": "MODERATE", "combined": "A", "partsUsed": ["A"]}
         ],
         "parts": [
             {
@@ -68,31 +57,15 @@ def simple_event_port_message() -> dict:
                 "duration": 0,
                 "arealPercentage": 0,
                 "region": "CONUS",
-                "product": {
-                    "fcst": [
-                        "NBM"
-                    ]
-                },
+                "product": {"fcst": ["NBM"]},
                 "field": "TEMPERATURE",
                 "units": "DEG F",
                 "relational": "GREATER THAN",
                 "thresh": 30,
-                "mapping": {
-                    "min": 0.0,
-                    "max": 75.0,
-                    "clip": "true"
-                }
+                "mapping": {"min": 0.0, "max": 75.0, "clip": "true"},
             }
         ],
-        "tags": {
-            "values": [
-                "Abq Temp"
-            ],
-            "keyValues": {
-                "name": "Abq TEMP",
-                "nwsOffice": "BOU"
-            }
-        },
+        "tags": {"values": ["Abq Temp"], "keyValues": {"name": "Abq TEMP", "nwsOffice": "BOU"}},
         "riskResults": [
             {
                 "evaluatedAt": "2022-11-11T14:54:32.100Z",
@@ -104,51 +77,31 @@ def simple_event_port_message() -> dict:
                         "partName": "A",
                         "dataName": "Temperature: 2m",
                         "dataLocation": "arn:aws:s3:::noaa-nbm-grib2-pds:",
-                        "issueDt": "2022-11-11T14:00:00.000Z"
+                        "issueDt": "2022-11-11T14:00:00.000Z",
                     }
                 ],
                 "dataSummary": [
                     {
-                        "validDt": [
-                            "2022-11-12T00:00:00.000Z"
-                        ],
+                        "validDt": ["2022-11-12T00:00:00.000Z"],
                         "data": [
                             {
                                 "name": "Abq TEMP",
                                 "type": "condition",
-                                "singleValue": [
-                                    0.18964463472366333
-                                ],
-                                "geoDist": [
-                                    {
-                                        "0.18964463472366333": 1
-                                    }
-                                ]
+                                "singleValue": [0.18964463472366333],
+                                "geoDist": [{"0.18964463472366333": 1}],
                             },
                             {
                                 "name": "A",
                                 "type": "criteria",
-                                "singleValue": [
-                                    0.18964463472366333
-                                ],
-                                "geoDist": [
-                                    {
-                                        "0.18964463472366333": 1
-                                    }
-                                ]
+                                "singleValue": [0.18964463472366333],
+                                "geoDist": [{"0.18964463472366333": 1}],
                             },
                             {
                                 "name": "A",
                                 "type": "raw",
-                                "singleValue": [
-                                    38.53400802612305
-                                ],
-                                "geoDist": [
-                                    {
-                                        "1.7941197416604382E-9": 1
-                                    }
-                                ]
-                            }
+                                "singleValue": [38.53400802612305],
+                                "geoDist": [{"1.7941197416604382E-9": 1}],
+                            },
                         ],
                     },
                 ],
@@ -165,9 +118,9 @@ def simple_event_port_message() -> dict:
                                 "startDt": "2022-11-12T00:00:00.000Z",
                                 "endDt": "2022-11-12T00:00:00.000Z",
                                 "maxAt": "2022-11-12T00:00:00.000Z",
-                                "empirical": "HIT"
+                                "empirical": "HIT",
                             }
-                        ]
+                        ],
                     },
                     {
                         "name": "A",
@@ -181,49 +134,54 @@ def simple_event_port_message() -> dict:
                                 "startDt": "2022-11-12T00:00:00.000Z",
                                 "endDt": "2022-11-12T00:00:00.000Z",
                                 "maxAt": "2022-11-12T00:00:00.000Z",
-                                "empirical": "HIT"
+                                "empirical": "HIT",
                             }
-                        ]
-                    }
-                ]
+                        ],
+                    },
+                ],
             }
-        ]
+        ],
     }
 
 
-def test_validate_event_port_message(event_port_validator: Validator,
-                                     simple_event_port_message: dict):
+def test_validate_event_port_message(
+    event_port_validator: Validator, simple_event_port_message: dict
+):
     try:
         event_port_validator.validate(simple_event_port_message)
     except ValidationError as exc:
-        assert False, f'Validate message raised an exception {exc}'
+        assert False, f"Validate message raised an exception {exc}"
 
 
-def test_validate_event_port_message_without_results(event_port_validator: Validator,
-                                                     simple_event_port_message: dict):
-    simple_event_port_message.pop('riskResults')
+def test_validate_event_port_message_without_results(
+    event_port_validator: Validator, simple_event_port_message: dict
+):
+    simple_event_port_message.pop("riskResults")
     with raises(ValidationError):
         event_port_validator.validate(simple_event_port_message)
 
 
-def test_validate_event_port_message_with_bad_geo_dist(event_port_validator: Validator,
-                                                       simple_event_port_message: dict):
-    data_summary = simple_event_port_message['riskResults'][0]['dataSummary']
-    criteria_geo_dist = data_summary[0]['data'][0]['geoDist']
+def test_validate_event_port_message_with_bad_geo_dist(
+    event_port_validator: Validator, simple_event_port_message: dict
+):
+    data_summary = simple_event_port_message["riskResults"][0]["dataSummary"]
+    criteria_geo_dist = data_summary[0]["data"][0]["geoDist"]
     criteria_geo_dist.append({"not a number": 3})
     with raises(ValidationError):
         event_port_validator.validate(simple_event_port_message)
 
 
-def test_validate_event_port_message_with_missing_metadata(event_port_validator: Validator,
-                                                           simple_event_port_message: dict):
-    simple_event_port_message['riskResults'][0]['metaData'][0]['states'].clear()
+def test_validate_event_port_message_with_missing_metadata(
+    event_port_validator: Validator, simple_event_port_message: dict
+):
+    simple_event_port_message["riskResults"][0]["metaData"][0]["states"].clear()
     with raises(ValidationError):
         event_port_validator.validate(simple_event_port_message)
 
 
-def test_validate_event_port_message_with_missing_type_in_metadata(event_port_validator: Validator,
-                                                                   simple_event_port_message: dict):
-    simple_event_port_message['riskResults'][0]['metaData'][0].pop('type')
+def test_validate_event_port_message_with_missing_type_in_metadata(
+    event_port_validator: Validator, simple_event_port_message: dict
+):
+    simple_event_port_message["riskResults"][0]["metaData"][0].pop("type")
     with raises(ValidationError):
         event_port_validator.validate(simple_event_port_message)

--- a/python/idsse_common/test/test_validate_new_data_schema.py
+++ b/python/idsse_common/test/test_validate_new_data_schema.py
@@ -1,4 +1,5 @@
-'''Test suite for new data message using validate_schema.py'''
+"""Test suite for new data message using validate_schema.py"""
+
 # ----------------------------------------------------------------------------------
 # Created on Mon Nov 20 2023
 #
@@ -22,7 +23,7 @@ from idsse.common.validate_schema import get_validator
 
 @fixture
 def new_data_validator() -> Validator:
-    schema_name = 'new_data_schema'
+    schema_name = "new_data_schema"
     return get_validator(schema_name)
 
 
@@ -33,7 +34,7 @@ def new_field_message() -> dict:
         "region": "CONUS",
         "issueDt": "2023-09-15T16:00:00.000Z",
         "validDt": "2023-09-17T06:00:00.000Z",
-        "field": "TEMP"
+        "field": "TEMP",
     }
 
 
@@ -44,7 +45,7 @@ def new_valid_message() -> dict:
         "region": "CONUS",
         "issueDt": "2023-09-15T16:00:00.000Z",
         "validDt": "2023-09-17T06:00:00.000Z",
-        "field": ["TEMP", "WINDSPEED"]
+        "field": ["TEMP", "WINDSPEED"],
     }
 
 
@@ -58,75 +59,77 @@ def new_issue_message() -> dict:
             "2023-09-15T17:00:00.000Z": ["TEMP", "WINDSPEED"],
             "2023-09-15T18:00:00.000Z": ["TEMP", "WINDSPEED"],
             "2023-09-15T19:00:00.000Z": ["TEMP", "WINDSPEED"],
-            "2023-09-15T20:00:00.000Z": ["TEMP", "WINDSPEED"]
-        }
+            "2023-09-15T20:00:00.000Z": ["TEMP", "WINDSPEED"],
+        },
     }
 
 
-def test_validate_new_field_data_message(new_data_validator: Validator,
-                                         new_field_message: dict):
+def test_validate_new_field_data_message(new_data_validator: Validator, new_field_message: dict):
     try:
         new_data_validator.validate(new_field_message)
     except ValidationError as exc:
-        assert False, f'Validate message raised an exception {exc}'
+        assert False, f"Validate message raised an exception {exc}"
 
 
-def test_validate_new_missing_field_data_message(new_data_validator: Validator,
-                                                 new_field_message: dict):
+def test_validate_new_missing_field_data_message(
+    new_data_validator: Validator, new_field_message: dict
+):
     # convert a new field message to a missing field message by changing 'field' key to 'missing'
-    new_field_message['missing'] = new_field_message.pop('field')
+    new_field_message["missing"] = new_field_message.pop("field")
     try:
         new_data_validator.validate(new_field_message)
     except ValidationError as exc:
-        assert False, f'Validate message raised an exception {exc}'
+        assert False, f"Validate message raised an exception {exc}"
 
 
-def test_validate_new_field_data_message_missing_region(new_data_validator: Validator,
-                                                        new_field_message: dict):
-    new_field_message.pop('region')
+def test_validate_new_field_data_message_missing_region(
+    new_data_validator: Validator, new_field_message: dict
+):
+    new_field_message.pop("region")
     with raises(ValidationError):
         new_data_validator.validate(new_field_message)
 
 
-def test_validate_new_valid_data_message(new_data_validator: Validator,
-                                         new_valid_message: dict):
+def test_validate_new_valid_data_message(new_data_validator: Validator, new_valid_message: dict):
     try:
         new_data_validator.validate(new_valid_message)
     except ValidationError as exc:
-        assert False, f'Validate message raised an exception {exc}'
+        assert False, f"Validate message raised an exception {exc}"
 
 
-def test_validate_new_missing_valid_data_message(new_data_validator: Validator,
-                                                 new_valid_message: dict):
+def test_validate_new_missing_valid_data_message(
+    new_data_validator: Validator, new_valid_message: dict
+):
     # convert new valid to missing valid by putting a field in missing list
-    fields = new_valid_message['field']
-    new_valid_message['field'] = fields[:-1]
-    new_valid_message['missing'] = [fields[-1]]
+    fields = new_valid_message["field"]
+    new_valid_message["field"] = fields[:-1]
+    new_valid_message["missing"] = [fields[-1]]
     try:
         new_data_validator.validate(new_valid_message)
     except ValidationError as exc:
-        assert False, f'Validate message raised an exception {exc}'
+        assert False, f"Validate message raised an exception {exc}"
 
 
-def test_validate_new_valid_data_message_bad_field(new_data_validator: Validator,
-                                                   new_valid_message: dict):
-    new_valid_message['field'].append('BAD_FIELD_NAME')
+def test_validate_new_valid_data_message_bad_field(
+    new_data_validator: Validator, new_valid_message: dict
+):
+    new_valid_message["field"].append("BAD_FIELD_NAME")
     with raises(ValidationError):
         new_data_validator.validate(new_valid_message)
 
 
-def test_validate_new_issue_data_message(new_data_validator: Validator,
-                                         new_issue_message: dict):
+def test_validate_new_issue_data_message(new_data_validator: Validator, new_issue_message: dict):
     try:
         new_data_validator.validate(new_issue_message)
     except ValidationError as exc:
-        assert False, f'Validate message raised an exception {exc}'
+        assert False, f"Validate message raised an exception {exc}"
 
 
-def test_validate_new_missing_issue_data_message(new_data_validator: Validator,
-                                                 new_issue_message: dict):
+def test_validate_new_missing_issue_data_message(
+    new_data_validator: Validator, new_issue_message: dict
+):
     # convert new issue to missing issue by putting some fields in missing object
-    fields = new_issue_message['field']
+    fields = new_issue_message["field"]
     found = {}
     missing = {}
     for valid_key in fields:
@@ -137,19 +140,20 @@ def test_validate_new_missing_issue_data_message(new_data_validator: Validator,
             found[valid_key] = []
             missing[valid_key] = fields[valid_key]
 
-    new_issue_message['field'] = found
-    new_issue_message['missing'] = missing
+    new_issue_message["field"] = found
+    new_issue_message["missing"] = missing
     try:
         new_data_validator.validate(new_issue_message)
     except ValidationError as exc:
-        assert False, f'Validate message raised an exception {exc}'
+        assert False, f"Validate message raised an exception {exc}"
 
 
-def test_validate_new_issue_data_message_bad_valid_string(new_data_validator: Validator,
-                                                          new_issue_message: dict):
+def test_validate_new_issue_data_message_bad_valid_string(
+    new_data_validator: Validator, new_issue_message: dict
+):
     # grab a good list of fields from the message
-    sample_fields = next(iter(new_issue_message['field'].values()))
+    sample_fields = next(iter(new_issue_message["field"].values()))
     # use the good list but with a bad valid string
-    new_issue_message['field']['Not a string rep of a valid date'] = sample_fields
+    new_issue_message["field"]["Not a string rep of a valid date"] = sample_fields
     with raises(ValidationError):
         new_data_validator.validate(new_issue_message)

--- a/rabbitmq/test/src/test.py
+++ b/rabbitmq/test/src/test.py
@@ -1,9 +1,9 @@
-'''/*******************************************************************************
- * Copyright (c) 2021 Regents of the University of Colorado. All rights reserved.
- *
- * Contributors:
- *     Michael Rabellino
- *******************************************************************************/'''
+"""/*******************************************************************************
+* Copyright (c) 2021 Regents of the University of Colorado. All rights reserved.
+*
+* Contributors:
+*     Michael Rabellino
+*******************************************************************************/"""
 
 import pika
 import sys
@@ -16,73 +16,86 @@ import argparse as ap
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
-    handlers=[
-        logging.StreamHandler(sys.stdout)
-    ]
+    handlers=[logging.StreamHandler(sys.stdout)],
 )
+
 
 def main():
     # handle command line arguments required to run the event portfolio manager service
-    usage = "usage: %prog --host host_name --username rabbitmq_username --password rabbitmq_password"
+    usage = (
+        "usage: %prog --host host_name --username rabbitmq_username --password rabbitmq_password"
+    )
     parser = ap.ArgumentParser()
-    parser.add_argument('--host', dest='host', help='The host name or address of the event portfolio RabbitMQ server to connect to.')
-    parser.add_argument('--username', dest='username', help='The username used to connect to the RabbitMQ server (configured by RabbitMQ)')
-    parser.add_argument('--password', dest='password', help='The password used to connect to the RabbitMQ server (configured by RabbitMQ)')
+    parser.add_argument(
+        "--host",
+        dest="host",
+        help="The host name or address of the event portfolio RabbitMQ server to connect to.",
+    )
+    parser.add_argument(
+        "--username",
+        dest="username",
+        help="The username used to connect to the RabbitMQ server (configured by RabbitMQ)",
+    )
+    parser.add_argument(
+        "--password",
+        dest="password",
+        help="The password used to connect to the RabbitMQ server (configured by RabbitMQ)",
+    )
     args = parser.parse_args()
 
     if args.host == None:
-        raise RuntimeError('Unknown RabbitMQ host, check configruation')
+        raise RuntimeError("Unknown RabbitMQ host, check configruation")
     host = args.host
 
     if args.username == None:
-        raise RuntimeError('Unknown RabbitMQ username, check configuration')
+        raise RuntimeError("Unknown RabbitMQ username, check configuration")
     username = args.username
 
     if args.password == None:
-        raise RuntimeError('Unknown RabbitMQ password, check configuration')
+        raise RuntimeError("Unknown RabbitMQ password, check configuration")
     password = args.password
 
     return host, username, password
 
-if __name__ == '__main__':
-    logging.info('Running python test to verify connection to RabbitMQ container')
+
+if __name__ == "__main__":
+    logging.info("Running python test to verify connection to RabbitMQ container")
     try:
         host, username, password = main()
-        queue = 'test-queue'
+        queue = "test-queue"
 
-        logging.info('    host:     %s', host)
-        logging.info('    username: %s', username)
-        logging.info('    password: %s', password)
-        logging.info('    queue:    %s', queue)
+        logging.info("    host:     %s", host)
+        logging.info("    username: %s", username)
+        logging.info("    password: %s", password)
+        logging.info("    queue:    %s", queue)
 
         credentials = pika.PlainCredentials(username, password)
-        connection = pika.BlockingConnection(pika.ConnectionParameters(host=host, credentials=credentials))
-        logging.info('Established connection to RabbitMQ %s', connection)
-        
+        connection = pika.BlockingConnection(
+            pika.ConnectionParameters(host=host, credentials=credentials)
+        )
+        logging.info("Established connection to RabbitMQ %s", connection)
+
         channel = connection.channel()
 
-        logging.info('Connecting to queue: %s', queue)
+        logging.info("Connecting to queue: %s", queue)
         channel.queue_declare(queue=queue, durable=True)
 
         # send a test json to the queue to verify it works
         message_body = json.dumps('{ "name":"John", "age":30, "car":null }')
 
         channel.basic_publish(
-            exchange='',
+            exchange="",
             routing_key=queue,
             body=message_body,
-            properties=pika.BasicProperties(
-                delivery_mode=2,
-                headers={'originator': 'test.py'}
-            )
+            properties=pika.BasicProperties(delivery_mode=2, headers={"originator": "test.py"}),
         )
 
-        time.sleep(5) # give it a few seconds for the server to log the queue message
+        time.sleep(5)  # give it a few seconds for the server to log the queue message
 
-        logging.info('Message sent')
+        logging.info("Message sent")
         connection.close()
 
     except Exception as e:
-        logging.error('Failed to test RabbitMQ driver due to exception: %s', str(e))
+        logging.error("Failed to test RabbitMQ driver due to exception: %s", str(e))
     finally:
-        logging.info('Test Complete!')
+        logging.info("Test Complete!")

--- a/rabbitmq/test/test_rabbitmq_driver.py
+++ b/rabbitmq/test/test_rabbitmq_driver.py
@@ -1,9 +1,9 @@
-'''/*******************************************************************************
- * Copyright (c) 2021 Regents of the University of Colorado. All rights reserved.
- *
- * Contributors:
- *     Michael Rabellino
- *******************************************************************************/'''
+"""/*******************************************************************************
+* Copyright (c) 2021 Regents of the University of Colorado. All rights reserved.
+*
+* Contributors:
+*     Michael Rabellino
+*******************************************************************************/"""
 
 import os
 import sys
@@ -16,124 +16,146 @@ import urllib, urllib.request
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
-    handlers=[
-        logging.StreamHandler(sys.stdout)
-    ]
+    handlers=[logging.StreamHandler(sys.stdout)],
 )
 
-if '__main__' == __name__:
-    logging.info('-----------------------------------------------------------')
-    logging.info('Running RabbitMQ test with arguments: ' + str(sys.argv))
+if "__main__" == __name__:
+    logging.info("-----------------------------------------------------------")
+    logging.info("Running RabbitMQ test with arguments: " + str(sys.argv))
 
     host = sys.argv[1]
     username = sys.argv[2]
     password = sys.argv[3]
 
     # static test configuration
-    network = 'rmq-test-network'
-    server_image = 'idss.engine.commons.rabbitmq.server:test'
-    test_image = 'idss.engine.commons.rabbitmq.client:test'
+    network = "rmq-test-network"
+    server_image = "idss.engine.commons.rabbitmq.server:test"
+    test_image = "idss.engine.commons.rabbitmq.client:test"
 
     # create a network for the RabbitMQ and event portfolio manager to run on
     try:
-        subprocess.check_output('docker network create ' + network, shell=True).decode('utf-8')
-        logging.info('Created docker network: %s', network)
+        subprocess.check_output("docker network create " + network, shell=True).decode("utf-8")
+        logging.info("Created docker network: %s", network)
     except Exception as e:
-        logging.warning('Container network already detected, continuing')
+        logging.warning("Container network already detected, continuing")
 
     # build the RabbitMQ server container
     try:
-        logging.info('Building RabbitMQ server image')
-        subprocess.check_output('cd ..; docker build -t ' + server_image + ' .', shell=True).decode('utf-8')
+        logging.info("Building RabbitMQ server image")
+        subprocess.check_output(
+            "cd ..; docker build -t " + server_image + " .", shell=True
+        ).decode("utf-8")
     except Exception as e:
-        logging.warning('Unable to build server container due to exception: %s', str(e))
+        logging.warning("Unable to build server container due to exception: %s", str(e))
 
     # build the test container
     try:
-        logging.info('Building test image')
-        subprocess.check_output('docker build -t ' + test_image + ' .', shell=True).decode('utf-8')
+        logging.info("Building test image")
+        subprocess.check_output("docker build -t " + test_image + " .", shell=True).decode("utf-8")
     except Exception as e:
-        logging.warning('Unable to build test container due to exception: %s', str(e))
-    
+        logging.warning("Unable to build test container due to exception: %s", str(e))
+
     # run the RabbitMQ Server container
     try:
-        logging.info('Running the RabbitMQ server container')
+        logging.info("Running the RabbitMQ server container")
         rabbit_mq_docker_server_cmd = (
-            'docker run --rm -d --name ' + host + ' ' +
-            '--network ' + network + ' ' +
-            '-e RABBITMQ_USER=' + username + ' ' +
-            '-e RABBITMQ_PASSWORD=' + password + ' ' +
-            '-p 15672:15672 ' +
-            server_image
+            "docker run --rm -d --name "
+            + host
+            + " "
+            + "--network "
+            + network
+            + " -e RABBITMQ_USER="
+            + username
+            + " -e RABBITMQ_PASSWORD="
+            + password
+            + " -p 15672:15672 "
+            + server_image
         )
         logging.info(rabbit_mq_docker_server_cmd)
-        subprocess.check_output(rabbit_mq_docker_server_cmd, shell=True).decode('utf-8')
+        subprocess.check_output(rabbit_mq_docker_server_cmd, shell=True).decode("utf-8")
     except Exception as e:
-        logging.warning('Unable to start the RabbitMQ server container due to exception: %s', str(e))
+        logging.warning(
+            "Unable to start the RabbitMQ server container due to exception: %s", str(e)
+        )
 
     # allow for some time for the RabbitMQ server to start
-    logging.info('Waiting for RabbitMQ server to start...')
+    logging.info("Waiting for RabbitMQ server to start...")
     time.sleep(20)
 
     # verify that RabbitMQ server is running
     try:
-        url = 'http://localhost:15672'
-        logging.info('Checking that RabbitMQ WebUI is running at: %s', url)
+        url = "http://localhost:15672"
+        logging.info("Checking that RabbitMQ WebUI is running at: %s", url)
         response = urllib.request.urlopen(url)
-        response_obj = response.read().decode('utf-8')
-        if (response_obj.find('Click here to log in') > 0):
-            logging.info('  RabbitMQ server is running')
+        response_obj = response.read().decode("utf-8")
+        if response_obj.find("Click here to log in") > 0:
+            logging.info("  RabbitMQ server is running")
         else:
-            logging.warning('  RabbitMQ server didnt start, test may fail...')
+            logging.warning("  RabbitMQ server didnt start, test may fail...")
     except Exception as e:
-        logging.warning('Problem connecting to RabbitMQ WebUI, verify it is running manually at: %s', url)
+        logging.warning(
+            "Problem connecting to RabbitMQ WebUI, verify it is running manually at: %s", url
+        )
 
     # run the test container
     try:
         rabbit_mq_docker_test_cmd = (
-            'docker run --network ' + network + ' ' +
-            test_image + ' ' +
-            '--host=' + host + ' ' +
-            '--username=' + username + ' ' +
-            '--password=' + password + ' '
+            "docker run --network "
+            + network
+            + " "
+            + test_image
+            + " --host="
+            + host
+            + " --username="
+            + username
+            + " --password="
+            + password
         )
         os.system(rabbit_mq_docker_test_cmd)
-        #subprocess.check_output(rabbit_mq_docker_test_cmd, shell=True).decode('utf-8')
+        # subprocess.check_output(rabbit_mq_docker_test_cmd, shell=True).decode('utf-8')
     except Exception as e:
-        logging.warning('Unable to run the test container due to exception: %s', str(e))
+        logging.warning("Unable to run the test container due to exception: %s", str(e))
 
     # cleanup
-    logging.info('-----------')
-    logging.info('Cleaning up')
+    logging.info("-----------")
+    logging.info("Cleaning up")
 
     # stop test server container
     try:
-        subprocess.check_output('docker stop ' + host, shell=True).decode('utf-8')
-        logging.info('Removed test RabbitMQ container: %s', host)
+        subprocess.check_output("docker stop " + host, shell=True).decode("utf-8")
+        logging.info("Removed test RabbitMQ container: %s", host)
     except Exception as e:
-        logging.warning('Unable to stop server container, please stop manually: $ docker stop %s', host)
+        logging.warning(
+            "Unable to stop server container, please stop manually: $ docker stop %s", host
+        )
     # remove test server image
     try:
-        subprocess.check_output('docker image rm -f ' + server_image, shell=True).decode('utf-8')
-        logging.info('Removed docker image: %s', server_image)
+        subprocess.check_output("docker image rm -f " + server_image, shell=True).decode("utf-8")
+        logging.info("Removed docker image: %s", server_image)
     except Exception as e:
-        logging.warning('Unable to remove server image, please delete manually: $ docker image rm %s', server_image)
+        logging.warning(
+            "Unable to remove server image, please delete manually: $ docker image rm %s",
+            server_image,
+        )
 
     # remove test container
     try:
-        subprocess.check_output('docker image rm -f ' + test_image, shell=True).decode('utf-8')
-        logging.info('Removed docker image: %s', test_image)
+        subprocess.check_output("docker image rm -f " + test_image, shell=True).decode("utf-8")
+        logging.info("Removed docker image: %s", test_image)
     except Exception as e:
-        logging.warning('Unable to remove test image, please delete manually: $ docker image rm %s', test_image)
+        logging.warning(
+            "Unable to remove test image, please delete manually: $ docker image rm %s", test_image
+        )
 
     # remove docker network
     try:
-        subprocess.check_output('docker network rm ' + network, shell=True).decode('utf-8')
-        logging.info('Removed docker network: %s', network)
+        subprocess.check_output("docker network rm " + network, shell=True).decode("utf-8")
+        logging.info("Removed docker network: %s", network)
     except Exception as e:
-        logging.warning('Unable to remove container network, please delete manually: $ docker network rm %s', network)
-    
+        logging.warning(
+            "Unable to remove container network, please delete manually: $ docker network rm %s",
+            network,
+        )
 
-    logging.info('Done')
-    logging.info('-----------------------------------------------------------')
-
+    logging.info("Done")
+    logging.info("-----------------------------------------------------------")


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-1244](https://linear.app/idss/issue/IDSSE-1244)

### Changes
<!-- Brief description of changes -->
- Auto-format all Python code based on opinionated [black](https://black.readthedocs.io/en/stable/index.html) style conventions
  - Formatter is called "black" as a reference to Henry Ford's famous quote about the Model T: "Any color the customer wants, as long as it's black."
- Add `black` to linter GitHub Action to confirm that (but not re-format) any code changes have been auto-formatted to black's styling.

Looks like a ton of code changes, but it shouldn't change any app behavior; just auto-formatting of existing code.

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
N/A
