### PR TITLE
bug: catch error on FileBasedLock release()

### DIFF
--- a/python/idsse_common/idsse/common/schema/support_profile.json
+++ b/python/idsse_common/idsse/common/schema/support_profile.json
@@ -77,6 +77,7 @@
     "properties": {
       "start": { "type": ["string", "null"] },
       "duration": { "type": ["number", "null"] },
+      "durationInMinutes": { "type": ["number", "null"] },
       "rrule": { "type": ["string", "null"] }
     }
   },

--- a/python/idsse_common/idsse/common/utils.py
+++ b/python/idsse_common/idsse/common/utils.py
@@ -161,7 +161,7 @@ class FileBasedLock:
             # Linux (and maybe Windows) don't support birthtime
             creation_time = os.stat(self._lock_path).st_ctime
         except FileNotFoundError:
-            # lock file disappeared since start of function call?? *shrug* treat it as unexpired
+            # lock file disappeared since start of function call?? Treat it as unexpired
             creation_time = datetime.now(UTC).timestamp()
         return (datetime.now(UTC).timestamp() - creation_time) >= self._max_age
 
@@ -198,7 +198,10 @@ class FileBasedLock:
         """Release the lock so other processes/threads can do I/O"""
         if not self.locked:
             return False
-        os.remove(self._lock_path)
+        try:
+            os.remove(self._lock_path)
+        except FileNotFoundError:
+            pass  # lock file disappeared since start of function call?? Treat it as released
         return True
 
     def _create_lockfile(self):


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
N/A

### Changes
<!-- Brief description of changes -->
- Some logs have shown uncaught errors when a service attempts to release a FileBasedLock: `FileNotFoundError`. 
  - If we try to release a file lock, and it's already released, catch the error and assume the lock can be abandoned.
 
### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
N/A