### PR TITLE
bug: idsse-1276: Publisher re-connect if connection closed

### DIFF
--- a/python/idsse_common/idsse/common/rabbitmq_utils.py
+++ b/python/idsse_common/idsse/common/rabbitmq_utils.py
@@ -49,6 +49,7 @@ class Conn(NamedTuple):
     port: int
     username: str
     password: str
+    heartbeat = 3600  # 60-minute heartbeats from broker (RabbitMQ default is 1 minute)
 
     @property
     def connection_parameters(self) -> ConnectionParameters:
@@ -59,6 +60,7 @@ class Conn(NamedTuple):
             virtual_host=self.v_host,
             port=self.port,
             credentials=PlainCredentials(self.username, self.password),
+            heartbeat=self.heartbeat,
         )
 
 

--- a/python/idsse_common/idsse/common/rabbitmq_utils.py
+++ b/python/idsse_common/idsse/common/rabbitmq_utils.py
@@ -241,9 +241,14 @@ class Publisher(Thread):
             try:
                 connection: BlockingConnection = self.channel.connection
                 connection.process_data_events(time_limit=1)
-            except (ConnectionClosed, ChannelClosed, ChannelWrongStateError) as exc:
+            except (
+                ConnectionClosed,
+                ConnectionResetError,
+                ChannelClosed,
+                ChannelWrongStateError,
+            ) as exc:
                 _logger.warning(
-                    "RabbitMQ connection not open, reconnecting now. Exc: [%s] %s",
+                    "RabbitMQ connection closed unexpectedly, reconnecting now. Exc: [%s] %s",
                     type(exc),
                     str(exc),
                 )

--- a/python/idsse_common/idsse/common/schema/support_profile.json
+++ b/python/idsse_common/idsse/common/schema/support_profile.json
@@ -77,6 +77,7 @@
     "properties": {
       "start": { "type": ["string", "null"] },
       "duration": { "type": ["number", "null"] },
+      "durationInMinutes": { "type": ["number", "null"] },
       "rrule": { "type": ["string", "null"] }
     }
   },

--- a/python/idsse_common/idsse/common/utils.py
+++ b/python/idsse_common/idsse/common/utils.py
@@ -161,7 +161,7 @@ class FileBasedLock:
             # Linux (and maybe Windows) don't support birthtime
             creation_time = os.stat(self._lock_path).st_ctime
         except FileNotFoundError:
-            # lock file disappeared since start of function call?? *shrug* treat it as unexpired
+            # lock file disappeared since start of function call?? Treat it as unexpired
             creation_time = datetime.now(UTC).timestamp()
         return (datetime.now(UTC).timestamp() - creation_time) >= self._max_age
 
@@ -198,7 +198,10 @@ class FileBasedLock:
         """Release the lock so other processes/threads can do I/O"""
         if not self.locked:
             return False
-        os.remove(self._lock_path)
+        try:
+            os.remove(self._lock_path)
+        except FileNotFoundError:
+            pass  # lock file disappeared since start of function call?? Treat it as released
         return True
 
     def _create_lockfile(self):

--- a/python/idsse_common/test/test_rabbitmq_utils.py
+++ b/python/idsse_common/test/test_rabbitmq_utils.py
@@ -220,7 +220,7 @@ def test_simple_publisher(monkeypatch: MonkeyPatch, mock_connection: Mock):
     mock_blocking_connection.assert_called_once()
     _channel = mock_blocking_connection.return_value.channel
     _channel.assert_called_once()
-    assert publisher.connection == mock_connection
+    assert publisher.channel.connection == mock_connection
 
     publisher.publish({"data": 123})
     assert "Publisher.publish" in str(mock_threadsafe.call_args[0][1])

--- a/python/idsse_common/test/test_rabbitmq_utils.py
+++ b/python/idsse_common/test/test_rabbitmq_utils.py
@@ -207,16 +207,17 @@ def test_default_exchange_does_not_declare_exchange(
     new_channel.basic_consume.assert_called_once()
 
 
-def test_simple_publisher(monkeypatch: MonkeyPatch, mock_connection: Mock):
+def test_simple_publisher(monkeypatch: MonkeyPatch, mock_connection: Mock, mock_channel: Mock):
+    mock_channel.connection = mock_connection
     # add mock to get Connection callback to invoke immediately
     mock_connection.add_callback_threadsafe = Mock(side_effect=lambda callback: callback())
-    mock_blocking_connection = Mock(return_value=mock_connection)
+    mock_blocking_connection = Mock(name="MockBlockingConnection", return_value=mock_connection)
     monkeypatch.setattr("idsse.common.rabbitmq_utils.BlockingConnection", mock_blocking_connection)
-
     mock_threadsafe = Mock()
     monkeypatch.setattr("idsse.common.rabbitmq_utils.threadsafe_call", mock_threadsafe)
 
     publisher = Publisher(CONN, RMQ_PARAMS.exchange)
+
     mock_blocking_connection.assert_called_once()
     _channel = mock_blocking_connection.return_value.channel
     _channel.assert_called_once()


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-1276](https://linear.app/idss/issue/IDSSE-1276)

### Changes
<!-- Brief description of changes -->
- In RabbitMQ utils `Publisher.blocking_publish()`, confirm that RabbitMQ connection/channel is open before trying to publish
  - If it isn't open, re-attempt connection and then publish message
- Default all RabbitMQ `Conn` to configure a `3600` second heartbeat from the RabbitMQ broker
  - RabbitMQ library default is 60 seconds
  - This might help prevent long-running connections from randomly getting closed by the broker. Might introduce new weird behavior across services though

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
We saw a bug in the dev environment where an instance of the NWSC Gateway had been idle for a while (days). When the Criteria Builder sent it a Support Profile to publish to RabbitMQ, it failed with an error message that the connection was in closed state.

Restarting the Kubernetes pod and re-submitting the Support Profile resolved the issue, but this required the dev team's manual intervention, which is bad.