### PR TITLE
RpcPublisher: stop suppressing TimeoutError

### DIFF
--- a/python/idsse_common/idsse/common/rabbitmq_rpc.py
+++ b/python/idsse_common/idsse/common/rabbitmq_rpc.py
@@ -144,12 +144,12 @@ class RpcPublisher:
         try:
             # block until callback runs (we'll know when the future's result has been changed)
             return request_future.result(timeout=self._timeout)
-        except TimeoutError:
-            logger.warning("Timed out waiting for response. rpc request_id: %s", request_id)
+        except TimeoutError as exc:
+            logger.debug("Timed out waiting for response. rpc request_id: %s", request_id)
             self._pending_requests.pop(request_id)  # stop tracking request Future
-            return None
+            raise exc
         except Exception as exc:  # pylint: disable=broad-exception-caught
-            logger.warning("Unexpected response from external service: %s", str(exc))
+            logger.warning("Unexpected error sending request to external service: %s", str(exc))
             self._pending_requests.pop(request_id)  # stop tracking request Future
             return None
 

--- a/python/idsse_common/test/test_rabbitmq_rpc.py
+++ b/python/idsse_common/test/test_rabbitmq_rpc.py
@@ -16,7 +16,7 @@ from typing import NamedTuple
 from unittest.mock import Mock
 from uuid import UUID
 
-from pytest import fixture, MonkeyPatch
+from pytest import fixture, raises, MonkeyPatch
 from pika import BasicProperties, BlockingConnection
 from pika.adapters.blocking_connection import BlockingChannel
 
@@ -186,9 +186,10 @@ def test_send_request_times_out_if_no_response(
         Mock(side_effect=lambda *_args, **_kwargs: None),
     )
 
-    result = _thread.send_request(RabbitMqMessage(json.dumps({"data": 123})))
+    with raises(TimeoutError) as exc:
+        _thread.send_request(RabbitMqMessage(json.dumps({"data": 123})))
     assert EXAMPLE_UUID not in _thread._pending_requests  # request was cleaned up
-    assert result is None
+    assert exc is not None
 
 
 def test_send_requests_returns_none_on_error(rpc_thread: RpcPublisher, mock_channel: Mock):


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-1243](https://linear.app/idss/issue/IDSSE-1243)

### Changes
<!-- Brief description of changes -->
- `RpcPublisher.send_request()`: allow the `TimeoutError` to be raised and handled by the caller as it wishes.
  - Previously a `WARNING` level log was always printed and None was returned. This assumes we know how the caller wants timeouts to be handled.
  - Example: the DAS data_preload service intentionally times out because it doesn't care about the responses. Because of previous RpcPublisher code, `WARNING` logs were constantly printed to the console even when the service was performing nominally.

> Note: this is a breaking change! Risk Processor and DAS data_preload currently expect `send_request()` to catch TimeoutErrors for them, and this PR would cause uncaught errors unless their code changes first.

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
N/A