### PR TITLE
JsonValidator: allow partial Event Portfolios

### DIFF
--- a/python/idsse_common/idsse/common/schema/event_portfolio_schema.json
+++ b/python/idsse_common/idsse/common/schema/event_portfolio_schema.json
@@ -1,16 +1,11 @@
-{   
-    "description": "Mechanism for making communicating an Event Portfolio",
-    "allOf": [
-        {"$ref": "criteria.json#/Criteria"}
-    ],
-    "properties": {
-        "riskResults": {
-            "type": "array",
-            "items": {"$ref": "risk_results.json#/RiskResults"},
-            "minItems": 1
-        }
-    },
-    "required": [
-        "riskResults"
-    ]
+{
+  "description": "Mechanism for making communicating an Event Portfolio",
+  "allOf": [{ "$ref": "criteria.json#/Criteria" }],
+  "properties": {
+    "riskResults": {
+      "type": "array",
+      "items": { "$ref": "risk_results.json#/RiskResults" }
+    }
+  },
+  "required": ["riskResults"]
 }

--- a/python/idsse_common/idsse/common/schema/tags.json
+++ b/python/idsse_common/idsse/common/schema/tags.json
@@ -8,7 +8,7 @@
       "createdAt": { "type": "string" },
       "status": {
         "type": "string",
-        "enum": ["CREATED", "PROCESSING", "COMPLETED", "FAILED"]
+        "enum": ["CREATED", "PROCESSING", "COMPLETE", "FAILED"]
       }
     },
     "patternProperties": {

--- a/python/idsse_common/idsse/common/schema/tags.json
+++ b/python/idsse_common/idsse/common/schema/tags.json
@@ -1,34 +1,34 @@
 {
-    "KeyValues": {
-        "description": "List of key,value pairs that are meaningful to user",
-        "type": "object",
-        "properties": {
-            "name": {"type": "string"},
-            "nwsOffice": {"type": "string"}
-        },
-        "patternProperties": {
-            "": {"type": "string"}
-        },
-        "required": [
-            "name",
-            "nwsOffice"
-        ]
+  "KeyValues": {
+    "description": "List of key,value pairs that are meaningful to user",
+    "type": "object",
+    "properties": {
+      "name": { "type": "string" },
+      "nwsOffice": { "type": "string" },
+      "createdAt": { "type": "string" },
+      "status": {
+        "type": "string",
+        "enum": ["CREATED", "IN_PROGRESS", "COMPLETED", "FAILED"]
+      }
     },
+    "patternProperties": {
+      "": { "type": "string" }
+    },
+    "required": ["name", "nwsOffice"]
+  },
 
-    "Tags": {
-        "description": "List of values and/or key,value pairs that are meaningful to user",
-        "type": "object",
-        "properties": {
-            "values": {
-                "description": "List of values that are meaningful to user",
-                "type": [ "array", "null" ],
-                "items": {"type": "string"}, 
-                "required": false
-            },
-            "keyValues":  {"$ref": "#/KeyValues"}
-        },
-        "required": [
-            "keyValues"
-        ]
-    }
+  "Tags": {
+    "description": "List of values and/or key,value pairs that are meaningful to user",
+    "type": "object",
+    "properties": {
+      "values": {
+        "description": "List of values that are meaningful to user",
+        "type": ["array", "null"],
+        "items": { "type": "string" },
+        "required": false
+      },
+      "keyValues": { "$ref": "#/KeyValues" }
+    },
+    "required": ["keyValues"]
+  }
 }

--- a/python/idsse_common/idsse/common/schema/tags.json
+++ b/python/idsse_common/idsse/common/schema/tags.json
@@ -8,7 +8,7 @@
       "createdAt": { "type": "string" },
       "status": {
         "type": "string",
-        "enum": ["CREATED", "IN_PROGRESS", "COMPLETED", "FAILED"]
+        "enum": ["CREATED", "PROCESSING", "COMPLETED", "FAILED"]
       }
     },
     "patternProperties": {

--- a/python/idsse_common/test/test_validate_event_port_schema.py
+++ b/python/idsse_common/test/test_validate_event_port_schema.py
@@ -153,6 +153,16 @@ def test_validate_event_port_message(
         assert False, f"Validate message raised an exception {exc}"
 
 
+def test_validate_event_port_with_empty_results(
+    event_port_validator: Validator, simple_event_port_message: dict
+):
+    simple_event_port_message["riskResults"] = []
+    try:
+        event_port_validator.validate(simple_event_port_message)
+    except ValidationError as exc:
+        assert False, f"Validate message raised an exception {exc}"
+
+
 def test_validate_event_port_message_without_results(
     event_port_validator: Validator, simple_event_port_message: dict
 ):


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-1292](https://linear.app/idss/issue/IDSSE-1292)

### Changes
<!-- Brief description of changes -->
- Change Event Portfolio jsonschema: `riskResults` can be empty array
- Also add optional `tags.keyValues` attribute called `status`

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
Now the Risk Processor can create partial EPs with `status`: `PROCESSING` with an empty array of `riskResults`. This means the DSD can no longer assume `riskResults` will always be an array sized 1, as partially completed or failed EPs may have no results.