### PR TITLE
bug: ConnectionResetError on Publisher.blocking_publish

### DIFF
--- a/python/idsse_common/idsse/common/rabbitmq_utils.py
+++ b/python/idsse_common/idsse/common/rabbitmq_utils.py
@@ -31,6 +31,7 @@ from pika.exceptions import (
     ChannelClosed,
     ChannelWrongStateError,
     ConnectionClosed,
+    StreamLostError,
 )
 from pika.frame import Method
 from pika.spec import Basic
@@ -246,6 +247,7 @@ class Publisher(Thread):
                 ConnectionResetError,
                 ChannelClosed,
                 ChannelWrongStateError,
+                StreamLostError,
             ) as exc:
                 _logger.warning(
                     "RabbitMQ connection closed unexpectedly, reconnecting now. Exc: [%s] %s",
@@ -291,11 +293,6 @@ class Publisher(Thread):
                   publisher is configured to confirm delivery will return False if
                   failed to confirm.
         """
-        if not self.channel.is_open:
-            # somehow RabbitMQ channel closed itself. Forceably create new connection/channel
-            logger.warning("Attempt to publish to closed connection. Reconnecting to RabbitMQ now")
-            self.channel = self._connect()
-
         return blocking_publish(
             self.channel, self._exch, RabbitMqMessage(message, properties, route_key), self._queue
         )


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-1301](https://linear.app/idss/issue/IDSSE-1301)

### Changes
<!-- Brief description of changes -->
- Don't try to re-establish RabbitMQ connection inside of `Publisher`
- Catch `StreamLostError` pika exception as well?

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
The previous bug fix was naive and did not fix the issue (likely due to some threading weirdness with who can make the RabbitMQ connection). Instead, the Publisher thread just hung forever, and the service that ran it never did anything until restarted.

This undoes the bad bug fix, and defers to each IDSS Engine service who uses `Publisher` to do any error handling or thread restarting. Not a great pattern because it means duplicate code across 3 services, but we need something that works right now.