### PR TITLE
bug: Unable to find appropriate packing

### DIFF
--- a/python/idsse_common/idsse/common/sci/bit_pack.py
+++ b/python/idsse_common/idsse/common/sci/bit_pack.py
@@ -18,10 +18,11 @@ import numpy
 
 
 class PackType(IntEnum):
-    """Enumerated type used to indicate if data is packed into a byte or short (16 bit)"""
+    """Enumerated type to mark if data is packed into a byte, short (16 bit), or int (32 bit)"""
 
     BYTE = 8
     SHORT = 16
+    INT = 32
 
 
 class PackInfo(NamedTuple):
@@ -294,8 +295,9 @@ def _pack_np_array_to_list(data: numpy.array, scale: float, offset: float) -> li
 #    return numpy.trunc(dip_data)
 
 
-# private lookup for the max value possible for bit packing type
-_max_values = {PackType.BYTE: 255, PackType.SHORT: 65535}
+# private lookup for the max value possible for bit packing type.
+# this is just memoization of `math.pow(2, pack_type) - 1` for pack_type in PackType enum
+_max_values = {PackType.BYTE: 255, PackType.SHORT: 65535, PackType.INT: 4294967295}
 
 _scale_lookup = {0: 1.0, 1: 0.1, 2: 0.01, 3: 0.001, 4: 0.0001, 5: 0.00001, 6: 0.000001}
 


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-1256](https://linear.app/idss/issue/IDSSE-1256)

### Changes
<!-- Brief description of changes -->
- Add `PackType` option to bit pack: `INT`. 
  - Maximum size of a data value is max int `(2 ^ 32)` or about 4.2 billion

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
Some NBM weather data had such a wide range of weather values that DAS web server would throw an error "Unable to find appropriate packing". For example, cloud ceiling caused this error because it had values from 100 ft to 291,000 ft. 

This error was because the `bit_pack` module was at most packing data into "SHORT"-sized blocks, which go from 0 to 65,535. Now we can bit-pack data into INT-sized memory blocks. It's not nearly as efficient for disk space/network usage, but if the data values vary wildly it may sometimes be needed.