### PR TITLE
feat: get issueDts from AWS in parallel

### DIFF
--- a/python/idsse_common/idsse/common/protocol_utils.py
+++ b/python/idsse_common/idsse/common/protocol_utils.py
@@ -99,7 +99,7 @@ class ProtocolUtils(ABC):
         issue_start: datetime | None = None,
         issue_end: datetime | None = None,
         time_delta: timedelta = timedelta(hours=1),
-        max_workers: int = 1,
+        max_workers: int = 24,
         **kwargs,
     ) -> Sequence[datetime]:
         """Determine the available issue date/times
@@ -110,7 +110,7 @@ class ProtocolUtils(ABC):
             issue_end (datetime): The newest date/time to look for. Defaults to now (UTC).
             time_delta (timedelta): The time step size. Defaults to 1 hour.
             max_workers (int): The number of Python threads to use to make AWS ls() calls.
-                Defaults to 1 (no parallel AWS calls).
+                Defaults to 24, which is reasonable. More threads will not necessarily run faster.
             kwargs: Additional arguments, e.g. region
 
         Returns:

--- a/python/idsse_common/idsse/common/rabbitmq_utils.py
+++ b/python/idsse_common/idsse/common/rabbitmq_utils.py
@@ -31,6 +31,7 @@ from pika.exceptions import (
     ChannelClosed,
     ChannelWrongStateError,
     ConnectionClosed,
+    StreamLostError,
 )
 from pika.frame import Method
 from pika.spec import Basic
@@ -246,6 +247,7 @@ class Publisher(Thread):
                 ConnectionResetError,
                 ChannelClosed,
                 ChannelWrongStateError,
+                StreamLostError,
             ) as exc:
                 _logger.warning(
                     "RabbitMQ connection closed unexpectedly, reconnecting now. Exc: [%s] %s",
@@ -291,11 +293,6 @@ class Publisher(Thread):
                   publisher is configured to confirm delivery will return False if
                   failed to confirm.
         """
-        if not self.channel.is_open:
-            # somehow RabbitMQ channel closed itself. Forceably create new connection/channel
-            logger.warning("Attempt to publish to closed connection. Reconnecting to RabbitMQ now")
-            self.channel = self._connect()
-
         return blocking_publish(
             self.channel, self._exch, RabbitMqMessage(message, properties, route_key), self._queue
         )

--- a/python/idsse_common/idsse/common/utils.py
+++ b/python/idsse_common/idsse/common/utils.py
@@ -314,7 +314,6 @@ def datetime_gen(
         max_num = min(max_num, dt_cnt) if max_num else dt_cnt
 
     for i in range(0, max_num):
-        logger.debug("dt generator %d/%d", i, max_num)
         yield dt_start + time_delta * i
 
 


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-1077](https://linear.app/idss/issue/IDSSE-1077)
[IDSSE-1301](https://linear.app/idss/issue/IDSSE-1301)

### Changes
<!-- Brief description of changes -->
- Don't try to re-establish RabbitMQ connection inside of `Publisher`
  - Catch `StreamLostError` pika exception as well?
- Look up `issueDt`s available in AWS for any dataset in parallel
  - Default is 24 threads, which was pretty fast during testing. `ProtocolUtils.get_issues()` accepts a custom value with `max_workers` argument.

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
Previously the ProtocolUtils would sequentially crawl a given AWS bucket (such as NBM) to discover the most recent issuance datetimes available. 
- So each AWS S3 `ls` call would wait to complete before attempting to `ls` the next folder. This meant that `get_issues()` response time increased linearly as the `num_issues` argument increased. 
- Getting the latest issueDt might take 500 ms, the latest 3 issueDts would take 1.5 seconds, the latest 6 issueDts would take about 3 seconds, and so on.

Now the function uses simple Python threading to look for recent issueDts in AWS in parallel, sending all the S3 `ls` requests at once and then sorting through what files each one found. By default it does this with up to 24 parallel threads, which just experimentally seemed to be a pretty fast number.