### PR TITLE
bug: get_issues() returning empty list

### DIFF
--- a/python/idsse_common/test/test_aws_utils.py
+++ b/python/idsse_common/test/test_aws_utils.py
@@ -178,7 +178,9 @@ def test_get_issues(aws_utils: AwsUtils, mock_exec_cmd):
 
 
 def test_get_issues_with_same_start_stop(aws_utils: AwsUtils, mock_exec_cmd):
-    result = aws_utils.get_issues(issue_start=EXAMPLE_ISSUE, issue_end=EXAMPLE_ISSUE)
+    result = aws_utils.get_issues(
+        issue_start=EXAMPLE_ISSUE, issue_end=EXAMPLE_ISSUE, num_issues=None
+    )
     assert len(result) == 1
     assert result[0] == EXAMPLE_ISSUE
 
@@ -201,7 +203,7 @@ def test_get_issues_latest_issue_default_today(
 
     assert result[0] == example_datetimes[0].replace(minute=0)
     # should have ls'd the 12Z directory in AWS
-    aws_dir = mock_exec_cmd.call_args[0][0][3]
+    aws_dir = mock_exec_cmd.mock_calls[0][1][0][3]
     assert aws_utils.path_builder.parse_dir(aws_dir)["issue.hour"] == example_datetimes[0].hour
 
     # simulate the passage of time: it's now 13:01 and a new 13Z issueDt has appeared


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-1077](https://linear.app/idss/issue/IDSSE-1077)

### Changes
<!-- Brief description of changes -->
- Fix bug introduced by #113 where `get_issues()` mishandled requests with `numIssue: 1` where that issueDt actually had no validDts yet

This was causing DAS New Data to never find any NBM issueDts, so it was always publishing messages with `fields: {}` and no new NBM runs were being processed by the Engine.

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
Sadly my changes in #113 were naive. 

We can't just send `numIssue` number of network calls to AWS S3 in parallel, wait for the responses, and return the issueDt folders that had valid GRIB files in them. We have to use an ugly old for-loop, because we don't know beforehand how many AWS S3 folders will be empty.
- If `numIssue` is 1, by sending 1 AWS `ls` call we were only getting the latest issueDt--which is often an empty folder at first.

