### PR TITLE
chore: add GridProj.slice_coords_to_slice_str()

### DIFF
--- a/python/idsse_common/idsse/common/sci/grid_proj.py
+++ b/python/idsse_common/idsse/common/sci/grid_proj.py
@@ -380,7 +380,8 @@ class GridProj:
         """
         # disassemble stringified coordinates of slice string into numbers
         coord_ints = [int(x) for x in re.findall(r"-?\d+", original)]
-        i_values, j_values = list(zip(coord_ints[:2], coord_ints[2:]))
+        i_values = coord_ints[:2]
+        j_values = coord_ints[2:]
 
         # clip all i values (first in coordinate pair) to be within i_interval (min, max)
         if i_interval:
@@ -393,4 +394,4 @@ class GridProj:
             j_values = [np.clip(val, j_min, j_max) for val in j_values]
 
         # rebuild Python slice string format
-        return f"[{i_values[0]}:{j_values[0]},{i_values[1]}:{j_values[1]}]"
+        return f"[{i_values[0]}:{i_values[1]},{j_values[0]}:{j_values[1]}]"

--- a/python/idsse_common/idsse/common/sci/grid_proj.py
+++ b/python/idsse_common/idsse/common/sci/grid_proj.py
@@ -15,7 +15,6 @@
 # cspell:word fliplr, flipud
 
 import json
-import logging
 from collections.abc import Sequence
 from enum import Enum
 from typing import Self, TypeVar, Iterable
@@ -26,8 +25,6 @@ from pyproj.enums import TransformDirection
 
 from idsse.common.utils import round_values, RoundingParam, RoundingMethod
 from idsse.common.sci.utils import coordinate_pairs_to_axes
-
-logger = logging.getLogger(__name__)
 
 # type hints
 Scalar = int | float | np.integer | np.float_

--- a/python/idsse_common/idsse/common/sci/utils.py
+++ b/python/idsse_common/idsse/common/sci/utils.py
@@ -7,7 +7,7 @@
 # Copyright (c) 2024 Colorado State University. All rights reserved.             (2)
 #
 # Contributors:
-#    Mackenzie Grimes
+#    Mackenzie Grimes (2)
 #
 # ------------------------------------------------------------------------------------
 

--- a/python/idsse_common/test/sci/test_grid_proj.py
+++ b/python/idsse_common/test/sci/test_grid_proj.py
@@ -278,20 +278,20 @@ def test_slice_coords_to_str(grid_proj: GridProj, slice_coords):
 
 @mark.parametrize("min_buffer", ["100", 100])
 def test_slice_coords_to_str_min_buffer(grid_proj: GridProj, min_buffer):
-    slice_coords = "[[-110,30],[-100,35]]"
+    slice_coords = "[[-110,30],[-100,31]]"
 
     slice_str = grid_proj.slice_coords_to_slice_str(slice_coords, min_buffer=min_buffer)
 
-    assert slice_str == "[618:1206,254:648]"
+    assert slice_str == "[618:1200,254:471]"
 
 
 def test_slice_coords_to_str_negative_buffer(grid_proj: GridProj):
-    slice_coords = "[[-110,30],[-100,35]]"
+    slice_coords = "[[-100,30],[-109,31]]"
     min_buffer = 1000
 
     slice_str = grid_proj.slice_coords_to_slice_str(slice_coords, min_buffer=min_buffer)
 
-    assert slice_str == "[-282:2106,-646:1548]"
+    assert slice_str == "[-240:2098,-674:1395]"
 
 
 @mark.parametrize("min_size", ["[400, 300]", [400, 300]])
@@ -304,10 +304,10 @@ def test_slice_coords_to_str_min_size(grid_proj: GridProj, min_size):
 
 
 def test_clip_slice_str_min_max():
-    slice_str = "[712:1112,-300:601]"
-    i_interval = (0, 500)  # no i max specified
-    j_interval = (0, 1000)  # no j max specified
-    expected = "[500:1000,0:601]"
+    slice_str = "[-712:1112,-300:601]"
+    i_interval = (0, 1000)  # no i max specified
+    j_interval = (0, 500)  # no j max specified
+    expected = "[0:1000,0:500]"
 
     result = GridProj.clip_slice_str(slice_str, i_interval, j_interval)
 
@@ -337,12 +337,12 @@ def test_clip_slice_str_min(slice_str, expected):
 
 @mark.parametrize(
     ["slice_str", "expected"],
-    [("[712:1112,300:601]", "[500:1000,300:601]"), ("[499:1112,-301:601]", "[499:1000,-301:601]")],
+    [("[712:1112,300:601]", "[712:1000,300:500]"), ("[-1:1112,-301:601]", "[-1:1000,-301:500]")],
 )
 def test_clip_slice_str_max(slice_str, expected):
-    i_interval = (None, 500)  # no i min specified
-    j_interval = (None, 1000)  # no j min specified
+    i_interval = (None, 1000)  # no i min specified
+    j_interval = (None, 500)  # no j min specified
 
     result = GridProj.clip_slice_str(slice_str, i_interval, j_interval)
 
-    assert result == expected  # any i/j value over 500/1000, respectively, is limited to its `max`
+    assert result == expected  # any i/j value over 1000/500 (respectively) is limited to its `max`


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-1262](https://linear.app/idss/issue/IDSSE-1262)

### Changes
<!-- Brief description of changes -->
- Add `slice_coords_to_slice_str()` function to GridProj
  - Convert lat/lon coordinates (e.g. `[(100.50, -40), (95, -41)]`) into Cartesian (x/y) coordinates based on the Grid Projection (e.g. Lambert Conformal CONUS), then print it as a Python slice string

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
This logic was determined to be needed by two classes in DAS (slice_opr and product_key), but unfortunately one imports the other which caused a Circular Import error, so we need an external function that they both can import.