### PR TITLE
bug: catch ChannelWrongStateError on publish

### DIFF
--- a/python/idsse_common/idsse/common/protocol_utils.py
+++ b/python/idsse_common/idsse/common/protocol_utils.py
@@ -123,12 +123,12 @@ class ProtocolUtils(ABC):
         if not issue_end:
             issue_end = datetime.now(UTC)
         if issue_start:
-            datetimes = list(datetime_gen(issue_end, time_delta, issue_start, num_issues))
+            datetimes = datetime_gen(issue_end, time_delta, issue_start, num_issues)
         else:
             # check if time delta is positive, if so make negative
             if time_delta > zero_time_delta:
                 time_delta = timedelta(seconds=-1.0 * time_delta.total_seconds())
-            datetimes = list(datetime_gen(issue_end, time_delta))
+            datetimes = datetime_gen(issue_end, time_delta)
 
         # build list of filepaths on the server for each dt (ignoring ones earlier than issue_dt)
         issue_filepaths = [
@@ -138,7 +138,7 @@ class ProtocolUtils(ABC):
         ]
 
         issues_with_valid_dts = self._get_unique_issues(issue_filepaths, num_issues, max_workers)
-        return sorted(list(issues_with_valid_dts))[:num_issues]
+        return sorted(list(issues_with_valid_dts), reverse=True)[:num_issues]
 
     def get_valids(
         self,
@@ -198,7 +198,7 @@ class ProtocolUtils(ABC):
     def _get_unique_issues(
         self,
         dir_paths: list[str],
-        num_issues: int,
+        num_issues: int | None,
         max_workers: int,
     ) -> list[datetime]:
         """

--- a/python/idsse_common/test/test_aws_utils.py
+++ b/python/idsse_common/test/test_aws_utils.py
@@ -173,8 +173,8 @@ def test_check_for_does_not_find_valid(aws_utils: AwsUtils, mock_exec_cmd):
 def test_get_issues(aws_utils: AwsUtils, mock_exec_cmd):
     result = aws_utils.get_issues(issue_start=EXAMPLE_ISSUE, issue_end=EXAMPLE_VALID, num_issues=2)
     assert len(result) == 2
-    assert result[0] == EXAMPLE_VALID - timedelta(hours=1)
-    assert result[1] == EXAMPLE_VALID
+    assert result[0] == EXAMPLE_VALID
+    assert result[1] == EXAMPLE_VALID - timedelta(hours=1)
 
 
 def test_get_issues_with_same_start_stop(aws_utils: AwsUtils, mock_exec_cmd):


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-1301](https://linear.app/idss/issue/IDSSE-1301)

### Changes
<!-- Brief description of changes -->
- Catch `ChannelWrongStateError` which pika throws if we attempt to publish messages to a closed channel/connection

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
Uncaught exception was causing callers of `Publisher.blocking_publish()` to still fail un-gracefully, because the services' code looks to the return value (`True`/`False`) to decide if it should restart its Publisher thread.

This catches yet another possible exception from pika and returns False to the caller, so the service can restart its Publisher.