### PR TITLE
bug: upgrade pygrib version from 2.1.6 to 2.1.8

### DIFF
--- a/docker/python-sci/Dockerfile
+++ b/docker/python-sci/Dockerfile
@@ -29,7 +29,7 @@ RUN conda config --set solver classic && \
     netcdf4==1.7.3 \
     h5netcdf==1.8.1 \
     h5py==3.15.1 \
-    pygrib==2.1.8 \
+    pygrib==2.1.4 \
     pyproj==3.7.2 \
     awscli==1.42.60 \
     jsonschema==4.25.1 \

--- a/docker/python-sci/Dockerfile
+++ b/docker/python-sci/Dockerfile
@@ -29,7 +29,7 @@ RUN conda config --set solver classic && \
     netcdf4==1.7.3 \
     h5netcdf==1.8.1 \
     h5py==3.15.1 \
-    pygrib==2.1.4 \
+    pygrib==2.1.8 \
     pyproj==3.7.2 \
     awscli==1.42.60 \
     jsonschema==4.25.1 \

--- a/docker/python-sci/Dockerfile
+++ b/docker/python-sci/Dockerfile
@@ -29,7 +29,7 @@ RUN conda config --set solver classic && \
     netcdf4==1.7.3 \
     h5netcdf==1.8.1 \
     h5py==3.15.1 \
-    pygrib==2.1.6 \
+    pygrib==2.1.8 \
     pyproj==3.7.2 \
     awscli==1.42.60 \
     jsonschema==4.25.1 \


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-1616](https://linear.app/idss/issue/IDSSE-1616)

### Changes
<!-- Brief description of changes -->
- Bump `pygrib` Python library version from `2.1.6` to `2.1.8`. [Changelog](https://github.com/jswhit/pygrib/blob/master/Changelog)

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
Only in the dev environment (not on my local `macos` machine), DAS was seeing constant errors when it attempted to read some GRIB variable with pygrib (see [DAS shrink_grib](https://github.com/NOAA-GSL/data-access-service/blob/62ec5dc685b930eb10fdc930f6022d15cc1389f8/python/das/data_retrieval/src/data_retrieval/grib_reader.py#L512) code):
```
RuntimeError: Unable to preserve variables from GRIB file due to exception: 
  (<class 'TypeError'>) an integer is required
```

The sole maintainer of pygrib has published a new minor version since we last attempted. Maybe there was some mysterious incompatibility with another library we were using that has since been fixed? Or moving from `2.1.4` to `2.1.6` introduced the error?