### PR TITLE
feat: jsonschema allow `PartnerVulnerabilities` format objects

### DIFF
--- a/python/idsse_common/idsse/common/schema/corr_id.json
+++ b/python/idsse_common/idsse/common/schema/corr_id.json
@@ -1,22 +1,18 @@
 {
-    "CorrId": {
-        "description": "Correlation identification used to track flow through the microservices",
-        "type": "object",
-        "properties": {
-            "originator": {
-                "type": "string",
-                "enum": ["IDSSe", "IMS", "CriteriaBuilder"]
-            },
-            "uuid": {
-                "type": "string",
-                "format": "uuid"
-            },
-            "issueDt": {"$ref": "timing.json#/TimeString"}
-        },
-        "required": [
-            "originator",
-            "uuid",
-            "issueDt"
-        ]
-    }
+  "CorrId": {
+    "description": "Correlation identification used to track flow through the microservices",
+    "type": "object",
+    "properties": {
+      "originator": {
+        "type": "string",
+        "enum": ["IDSSe", "IMS", "NWSConnect", "CriteriaBuilder"]
+      },
+      "uuid": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "issueDt": { "$ref": "timing.json#/TimeString" }
+    },
+    "required": ["originator", "uuid", "issueDt"]
+  }
 }

--- a/python/idsse_common/idsse/common/schema/criteria.json
+++ b/python/idsse_common/idsse/common/schema/criteria.json
@@ -1,32 +1,32 @@
 {
-    "Criteria": {
-        "description": "Mechanism for defining criteria",
-        "type": "object",
-        "properties": {   
-            "corrId": {"$ref": "corr_id.json#/CorrId"},
-            "issueDt": {"$ref": "timing.json#/TimeString"},
-            "tags": {"$ref": "tags.json#/Tags"},
-            "validDt": {"$ref": "timing.json#/Timing"},
-            "location": {"$ref": "location.json#/Location"},
-            "conditions": {
-                "type": "array",
-                "items": {"$ref": "condition.json#/Condition"},
-                "minItems": 1
-            },
-            "parts": {
-                "type": "array",
-                "items": {"$ref": "translated_data.json#/TranslatedData"},
-                "minItems": 1
-            }
-        },
-        "required": [
-            "corrId",
-            "issueDt",
-            "tags",
-            "validDt",
-            "location",
-            "conditions",
-            "parts"
-        ]
-    }
+  "Criteria": {
+    "description": "Mechanism for defining criteria",
+    "type": "object",
+    "properties": {
+      "corrId": { "$ref": "corr_id.json#/CorrId" },
+      "issueDt": { "$ref": "timing.json#/TimeString" },
+      "tags": { "$ref": "tags.json#/Tags" },
+      "validDt": { "$ref": "timing.json#/Timing" },
+      "location": { "$ref": "location.json#/Location" },
+      "conditions": {
+        "type": "array",
+        "items": { "$ref": "condition.json#/Condition" },
+        "minItems": 1
+      },
+      "parts": {
+        "type": "array",
+        "items": { "$ref": "translated_data.json#/TranslatedData" },
+        "minItems": 1
+      }
+    },
+    "required": [
+      "corrId",
+      "issueDt",
+      "tags",
+      "validDt",
+      "location",
+      "conditions",
+      "parts"
+    ]
+  }
 }

--- a/python/idsse_common/idsse/common/schema/gateway_web_request.json
+++ b/python/idsse_common/idsse/common/schema/gateway_web_request.json
@@ -1,6 +1,6 @@
 {
   "GatewayWebRequest": {
-    "description": "Definition of an NWSC Gateway request via the web API to publish new Support Profile/Criteria",
+    "description": "Definition of an NWSC Gateway request via the web API to publish new Support Profile/Vulnerability/Criteria",
     "type": "object",
     "properties": {
       "issueDt": { "$ref": "timing.json#/TimeString" },
@@ -12,10 +12,14 @@
       },
       "originator": { "type": "string" },
       "criteria": { "$ref": "criteria.json#/Criteria" },
-      "supportProfile": { "$ref": "support_profile.json#/SupportProfile" }
+      "supportProfile": { "$ref": "support_profile.json#/SupportProfile" },
+      "vulnerability": {
+        "$ref": "partner_vulnerability.json#/PartnerVulnerability"
+      }
     },
     "oneOf": [
       { "required": ["supportProfile", "issueDt"] },
+      { "required": ["vulnerability", "issueDt"] },
       { "required": ["criteria"] }
     ]
   }

--- a/python/idsse_common/idsse/common/schema/new_data.json
+++ b/python/idsse_common/idsse/common/schema/new_data.json
@@ -1,98 +1,78 @@
 {
-    "NewField": {
-        "description": "New Field available message, broadcasted each time a new data field is found",
-        "type": "object",
-        "properties": {
-            "product": {"$ref": "product.json#/Product"},
-            "region": {"$ref": "region.json#/Region"},
-            "issueDt": {"$ref": "timing.json#/TimeString"},
-            "validDt": {"$ref": "timing.json#/TimeString"},
-            "field": {"$ref": "field.json#/FieldName"},
-            "missing": {"$ref": "field.json#/FieldName"}
-        },
-        "additionalProperties": false,
-        "required": [
-            "product",
-            "region",
-            "issueDt",
-            "validDt"
-        ],
-        "oneOf": [
-            {
-                "required": [
-                    "field"
-                ]
-            },
-            {
-                "required": [
-                    "missing"
-                ]
-            }
-        ]
+  "NewField": {
+    "description": "New Field available message, broadcasted each time a new data field is found",
+    "type": "object",
+    "properties": {
+      "product": { "$ref": "product.json#/Product" },
+      "region": { "$ref": "region.json#/Region" },
+      "issueDt": { "$ref": "timing.json#/TimeString" },
+      "validDt": { "$ref": "timing.json#/TimeString" },
+      "field": { "$ref": "field.json#/FieldName" },
+      "missing": { "$ref": "field.json#/FieldName" }
     },
-    
-    "NewValid": {
-        "description": "New Valid available message, broadcasted each time all fields for an issue/valid are found",
-        "type": "object",
-        "properties": {
-            "product": {"$ref": "product.json#/Product"},
-            "region": {"$ref": "region.json#/Region"},
-            "issueDt": {"$ref": "timing.json#/TimeString"},
-            "validDt": {"$ref": "timing.json#/TimeString"},
-            "field": {"$ref": "field.json#/FieldList"},
-            "missing": {"$ref": "field.json#/FieldList"}
-        },
-        "additionalProperties": false,
-        "required": [
-            "product",
-            "region",
-            "issueDt",
-            "validDt",
-            "field"
-        ]
+    "additionalProperties": false,
+    "required": ["product", "region", "issueDt", "validDt"],
+    "oneOf": [
+      {
+        "required": ["field"]
+      },
+      {
+        "required": ["missing"]
+      }
+    ]
+  },
+
+  "NewValid": {
+    "description": "New Valid available message, broadcasted each time all fields for an issue/valid are found",
+    "type": "object",
+    "properties": {
+      "product": { "$ref": "product.json#/Product" },
+      "region": { "$ref": "region.json#/Region" },
+      "issueDt": { "$ref": "timing.json#/TimeString" },
+      "validDt": { "$ref": "timing.json#/TimeString" },
+      "field": { "$ref": "field.json#/FieldList" },
+      "missing": { "$ref": "field.json#/FieldList" }
     },
-    
-    "NewIssue": {
-        "description": "New Issue available message, broadcasted each time all valids for an issue are found",
+    "additionalProperties": false,
+    "required": ["product", "region", "issueDt", "validDt", "field"]
+  },
+
+  "NewIssue": {
+    "description": "New Issue available message, broadcasted each time all valids for an issue are found",
+    "type": "object",
+    "properties": {
+      "product": { "$ref": "product.json#/Product" },
+      "region": { "$ref": "region.json#/Region" },
+      "issueDt": { "$ref": "timing.json#/TimeString" },
+      "validDt": { "$ref": "timing.json#/TimeString" },
+      "field": {
         "type": "object",
-        "properties": {
-            "product": {"$ref": "product.json#/Product"},
-            "region": {"$ref": "region.json#/Region"},
-            "issueDt": {"$ref": "timing.json#/TimeString"},
-            "validDt": {"$ref": "timing.json#/TimeString"},
-            "field": {
-                "type": "object",
-                "patternProperties": {
-                    "^(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2}(?:\\.\\d*)?)((-(\\d{2}):(\\d{2})|Z)?)$": {
-                        "$ref": "field.json#/FieldList"
-                    },
-                    "[^0-9.+-:TZ]": {"not": {}}
-                }
-            },
-            "missing": {
-                "type": "object",
-                "patternProperties": {
-                    "^(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2}(?:\\.\\d*)?)((-(\\d{2}):(\\d{2})|Z)?)$": {
-                        "$ref": "field.json#/FieldList"
-                    },
-                    "[^0-9.+-:TZ]": {"not": {}}
-                }
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "product",
-            "region",
-            "issueDt",
-            "field"
-        ]
-    },    
-    "NewData": {
-        "description": "Either a NewField, NewValid, or NewIssue",
-        "oneOf": [
-            {"$ref": "#/NewField"},
-            {"$ref": "#/NewValid"},
-            {"$ref": "#/NewIssue"}
-        ]
-    }
+        "patternProperties": {
+          "^(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2}(?:\\.\\d*)?)((-(\\d{2}):(\\d{2})|Z)?)$": {
+            "$ref": "field.json#/FieldList"
+          },
+          "[^0-9.+-:TZ]": { "not": {} }
+        }
+      },
+      "missing": {
+        "type": "object",
+        "patternProperties": {
+          "^(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2}(?:\\.\\d*)?)((-(\\d{2}):(\\d{2})|Z)?)$": {
+            "$ref": "field.json#/FieldList"
+          },
+          "[^0-9.+-:TZ]": { "not": {} }
+        }
+      }
+    },
+    "additionalProperties": false,
+    "required": ["product", "region", "issueDt", "field"]
+  },
+  "NewData": {
+    "description": "Either a NewField, NewValid, or NewIssue",
+    "oneOf": [
+      { "$ref": "#/NewField" },
+      { "$ref": "#/NewValid" },
+      { "$ref": "#/NewIssue" }
+    ]
+  }
 }

--- a/python/idsse_common/idsse/common/schema/partner_vulnerability.json
+++ b/python/idsse_common/idsse/common/schema/partner_vulnerability.json
@@ -1,0 +1,153 @@
+{
+  "Phrase": {
+    "description": "Definition of one weather field threshold. Akin to Criteria 'part'",
+    "type": "object",
+    "properties": {
+      "type": { "type": "string" },
+      "phraseId": { "type": "string" },
+      "probability": { "type": "number" },
+      "environmentalConditionType": { "type": "string" },
+      "wwaProduct": { "type": "string" },
+      "condition": { "type": "string" },
+      "value": { "type": "string" },
+      "timeFrame": { "type": "string" },
+      "minDuration": { "type": "string" },
+      "dataSource": { "type": "string" },
+      "dataParameter": { "type": "string" }
+    },
+    "required": [
+      "dataSource",
+      "environmentalConditionType",
+      "condition",
+      "value",
+      "units"
+    ]
+  },
+
+  "Severity": {
+    "description": "Definition of weather field thresholds to reach this severity impact",
+    "type": "object",
+    "properties": {
+      "severity": { "type": "string" },
+      "encodedRepresentation": {
+        "description": "Compound statement of relationship of all weather thresholds phrases, by phraseId",
+        "type": "string"
+      },
+      "map": {
+        "type": "object",
+        "patternProperties": {
+          "^[a-zA-Z]*$": { "$ref": "#/Phrase" }
+        }
+      }
+    },
+    "required": ["severity", "encodedRepresentation", "map"]
+  },
+
+  "NonImpactThresholds": {
+    "description": "Support Profile weather conditions to determine if impact is met/not met",
+    "type": "object",
+    "properties": {
+      "phrasesForAllSeverities": {
+        "type": "object",
+        "properties": {
+          "MINOR": { "$ref": "#/Severity" },
+          "MODERATE": { "$ref": "#/Severity" },
+          "SEVERE": { "$ref": "#/Severity" },
+          "EXTREME": { "$ref": "#/Severity" }
+        },
+        "oneOf": [
+          { "required": ["MINOR"] },
+          { "required": ["MODERATE"] },
+          { "required": ["SEVERE"] },
+          { "required": ["EXTREME"] }
+        ]
+      },
+      "allTypesAsStrings": {
+        "type": "array",
+        "items": { "type": "string" },
+        "minItems": 1
+      }
+    },
+    "required": ["phrasesForAllSeverities", "allTypesAsStrings"]
+  },
+
+  "Timing": {
+    "description": "Time range of Support Profile event",
+    "type": "object",
+    "properties": {
+      "start": { "type": ["string", "null"] },
+      "duration": { "type": ["number", "null"] },
+      "durationInMinutes": { "type": ["number", "null"] },
+      "rrule": { "type": ["string", "null"] }
+    }
+  },
+
+  "Location": {
+    "description": "Geographic location of Support Profile event",
+    "type": "object",
+    "properties": {
+      "createdAt": { "type": "string" },
+      "lastModified": { "type": "string" },
+      "name": { "type": "string" },
+      "geomAsString": { "type": "string" },
+      "geometryType": {
+        "type": "string",
+        "enum": ["POINT", "LINESTRING", "POLYGON", "CIRCLE"]
+      },
+      "geoShapeCreationMethod": { "type": "string" },
+      "validTime": { "type": ["string", "null"] },
+      "creationMethod": { "type": "string" },
+      "notes": { "type": "string" },
+      "editable": { "type": "boolean" },
+      "minElevation": { "type": "number" },
+      "maxElevation": { "type": "number" },
+      "original": { "type": "null" },
+      "address": { "type": "null" },
+      "userData": { "type": "null" }
+    },
+    "required": ["geomAsString", "name"]
+  },
+
+  "Setting": {
+    "description": "Definition of Support Profile event location and timing",
+    "type": "object",
+    "properties": {
+      "id": { "type": "string" },
+      "name": { "type": "string" },
+      "driverType": { "type": "string" },
+      "locations": {
+        "type": "array",
+        "items": { "$ref": "#/Location" },
+        "minItems": 1
+      },
+      "timing": { "$ref": "#/Timing" },
+      "nationalSecurity": { "type": "boolean" },
+      "website": { "type": "string" },
+      "numberOfPeople": { "type": "number" }
+    }
+  },
+
+  "PartnerVulnerability": {
+    "description": "Mechanism for defining an NWS Connect Partner Vulnerability",
+    "type": "object",
+    "properties": {
+      "id": { "type": "string" },
+      "name": { "type": "string" },
+      "primaryOfficeId": { "type": "string" },
+      "geometry": { "type": "object" },
+      "activeTime": { "type": "object" },
+      "hazards": { "type": "array", "items": { "type": "object" } },
+      "notes": { "type": "string" },
+      "support": { "type": "object" },
+      "scheduledEventData": { "type": "object" }
+    },
+    "required": [
+      "id",
+      "name",
+      "primaryOfficeId",
+      "geometry",
+      "activeTime",
+      "hazards"
+    ]
+  }
+}

--- a/python/idsse_common/idsse/common/sci/bit_pack.py
+++ b/python/idsse_common/idsse/common/sci/bit_pack.py
@@ -109,7 +109,7 @@ def pack_to_list(
     pack_info: PackInfo | None = None,
     decimals: int | None = None,
     in_place: bool = True,
-):
+) -> PackData:
     """Preform bit packing of input data, utilizing the the pack_info if provided or
     a derived pack_info if not.
 


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-165](https://linear.app/idss/issue/IDSSE-165)

### Changes
<!-- Brief description of changes -->
Just jsonschema changes to support new PartnerVulnerability objects (will replace deprecated SupportProfile):

- feat: add `PartnerVulnerability` to jsonschema
- feat: allow NWSC Gateway requests to have `vulnerability` data instead of `supportProfile` data
- feat: add `NWSConnect` as permitted corrId.originator values

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
N/A