### PR TITLE
fix: Boto3Utils not thread-safe (cannot pickle _thread)

### DIFF
--- a/python/idsse_common/idsse/common/aws_utils.py
+++ b/python/idsse_common/idsse/common/aws_utils.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 class AwsUtils(ProtocolUtils):
     """AWS Utility Class"""
 
-    def ls(self, path: str, prepend_path: bool = True) -> Sequence[str]:
+    def ls(self, path: str, prepend_path: bool = True, **kwargs) -> Sequence[str]:
         """Execute a 'ls' on the AWS s3 bucket specified by path
 
         Args:
@@ -52,7 +52,12 @@ class AwsUtils(ProtocolUtils):
         return [filename.split(" ")[-1] for filename in commands_result]
 
     def cp(
-        self, path: str, dest: str, concurrency: int | None = None, chunk_size: int | None = None
+        self,
+        path: str,
+        dest: str,
+        concurrency: int | None = None,
+        chunk_size: int | None = None,
+        **kwargs,
     ) -> bool:
         """Execute a 'cp' on the AWS s3 bucket specified by path, dest. Attempts to use
         [s5cmd](https://github.com/peak/s5cmd) to copy the file from S3 with parallelization,

--- a/python/idsse_common/idsse/common/boto3_utils.py
+++ b/python/idsse_common/idsse/common/boto3_utils.py
@@ -24,92 +24,6 @@ from .protocol_utils import ProtocolUtils
 
 logger = logging.getLogger(__name__)
 
-# all request S3 costs (if any) should be assumed by the AWS account running this code
-REQUEST_PAYER = "requester"
-
-
-class Boto3Utils(ProtocolUtils):
-    """Boto3 (AWS) utility class that supports AWS IAM authentication"""
-
-    PROTOCOL = "s3://"
-
-    def __init__(self, basedir: str, subdir: str, file_base: str, file_ext: str):
-        # create new Session which holds AWS IAM Tokens, if needed, to authenticate with S3 bucket
-        self._session = AwsSession()
-        super().__init__(basedir, subdir, file_base, file_ext)
-
-    @property
-    def credentials(self) -> botocore.credentials.Credentials | None:
-        """Current AWS Credentials dictionary for this active Session, if IAM Role assumed. None if
-        no AWS_* environment variables present (bucket doesn't require manual IAM Role)
-        """
-        return self._session.credentials
-
-    def ls(self, path: str, prepend_path: bool = True) -> Sequence[str]:
-        """Execute a 'ls' on the AWS s3 bucket specified by path
-
-        Args:
-            path (str): path to S3 bucket directory, e.g. s3://my-bucket/
-            prepend_path (bool): Add the full s3 bucket path to any returned filenames.
-                Defaults to True.
-
-        Returns:
-            Sequence[str]: The results sent to stdout from executing a 'ls' on passed path
-        """
-        if path[-1] != "/":
-            path = path + "/"  # ensure a trailing slash, which is expected by S3
-
-        # example: (s3://my-bucket-name/deeply/nested/object/here.txt)
-        # ignore protocol (s3://), then everything up until the first / is the bucket name
-        bucket, prefix = path.replace(self.PROTOCOL, "").split("/", maxsplit=1)
-        s3 = self._session.client("s3")
-        try:
-            response: dict = s3.list_objects_v2(
-                Bucket=bucket, Prefix=prefix, Delimiter="/", RequestPayer=REQUEST_PAYER
-            )
-        except PermissionError:
-            return []
-
-        # boto3 returns children under .zarr directory as well as *.zarr/; combine any files
-        # and directories at this level into general "objects"
-        found_objects: list[str] = [
-            file["Prefix"] for file in response.get("CommonPrefixes", [])
-        ] + [file["Key"] for file in response.get("Contents", [])]
-
-        if prepend_path:
-            return [os.path.join(self.PROTOCOL, bucket, obj) for obj in found_objects]
-        # boto3 returns full object path; drop everything except last level
-        return [file.split("/")[-1] for file in found_objects]
-
-    def cp(self, path: str, dest: str) -> bool:
-        """Execute a 'cp' on the AWS s3 bucket specified by path, destination. Note: this uses the
-        basic `boto3.download_file()` and may be quite slow.
-
-        Args:
-            path (str): Relative or Absolute path to the object to be copied
-            dest (str): The destination location
-
-        Returns:
-            bool: Returns True if copy is successful
-        """
-        if path[-1] != "/":
-            path = path + "/"  # ensure a trailing slash, which is expected by S3
-
-        # ignore protocol (s3://), then everything up until the first / is the bucket name
-        bucket, object_key = path.replace(self.PROTOCOL, "").split("/", maxsplit=1)
-
-        s3 = self._session.client("s3")
-        try:
-            s3.download_file(
-                Bucket=bucket,
-                Key=object_key,
-                Filename=dest,
-                ExtraArgs={"RequestPayer": REQUEST_PAYER},
-            )
-            return True
-        except PermissionError:
-            return False
-
 
 class AwsSession:
     """Persist an AWS session in memory, refreshing credentials when needed"""
@@ -232,3 +146,92 @@ class AwsSession:
             ),
             creds["Expiration"],
         )
+
+
+class Boto3Utils(ProtocolUtils):
+    """Boto3 (AWS) utility class that supports AWS IAM authentication"""
+
+    PROTOCOL = "s3://"
+    # all request S3 costs (if any) should be assumed by the AWS account running this code
+    REQUEST_PAYER = "requester"
+
+    def ls(self, path: str, prepend_path: bool = True, **kwargs) -> Sequence[str]:
+        """Execute a 'ls' on the AWS s3 bucket specified by path
+
+        Args:
+            path (str): path to S3 bucket directory, e.g. s3://my-bucket/
+            prepend_path (bool): Add the full s3 bucket path to any returned filenames.
+                Defaults to True.
+            kwargs (optional, kwargs): `aws_session=AwsSession` instance if AWS authentication is
+                needed to access this S3 bucket
+
+        Returns:
+            Sequence[str]: The results sent to stdout from executing a 'ls' on passed path
+        """
+        if path[-1] != "/":
+            path = path + "/"  # ensure a trailing slash, which is expected by S3
+
+        # example: (s3://my-bucket-name/deeply/nested/object/here.txt)
+        # ignore protocol (s3://), then everything up until the first / is the bucket name
+        bucket, prefix = path.replace(self.PROTOCOL, "").split("/", maxsplit=1)
+
+        # if caller passed existing AwsSession, reuse that to call S3 with needed credentials;
+        # otherwise create a Session and authenticate on the fly
+        if not (session := kwargs.get("aws_session")):
+            # create new Session which holds IAM Tokens, if needed, to authenticate with S3 bucket
+            session = AwsSession()
+
+        s3 = session.client("s3")
+        try:
+            response: dict = s3.list_objects_v2(
+                Bucket=bucket, Prefix=prefix, Delimiter="/", RequestPayer=self.REQUEST_PAYER
+            )
+        except PermissionError:
+            return []
+
+        # boto3 returns children under .zarr directory as well as *.zarr/; combine any files
+        # and directories at this level into general "objects"
+        found_objects: list[str] = [
+            file["Prefix"] for file in response.get("CommonPrefixes", [])
+        ] + [file["Key"] for file in response.get("Contents", [])]
+
+        if prepend_path:
+            return [os.path.join(self.PROTOCOL, bucket, obj) for obj in found_objects]
+        # boto3 returns full object path; drop everything except last level
+        return [file.split("/")[-1] for file in found_objects]
+
+    def cp(self, path: str, dest: str, **kwargs) -> bool:
+        """Execute a 'cp' on the AWS s3 bucket specified by path, destination. Note: this uses the
+        basic `boto3.download_file()` and may be quite slow.
+
+        Args:
+            path (str): Relative or Absolute path to the object to be copied
+            dest (str): The destination location
+            kwargs (optional, kwargs): `aws_session=AwsSession` instance if AWS authentication is
+                needed to access this S3 bucket
+
+        Returns:
+            bool: Returns True if copy is successful
+        """
+        if path[-1] != "/":
+            path = path + "/"  # ensure a trailing slash, which is expected by S3
+
+        # ignore protocol (s3://), then everything up until the first / is the bucket name
+        bucket, object_key = path.replace(self.PROTOCOL, "").split("/", maxsplit=1)
+
+        # if caller passed existing AwsSession, reuse that to call S3 with needed credentials;
+        # otherwise create a Session and authenticate on the fly
+        if not (session := kwargs.get("aws_session")):
+            session = AwsSession()
+
+        s3 = session.client("s3")
+        try:
+            s3.download_file(
+                Bucket=bucket,
+                Key=object_key,
+                Filename=dest,
+                ExtraArgs={"RequestPayer": self.REQUEST_PAYER},
+            )
+            return True
+        except PermissionError:
+            return False

--- a/python/idsse_common/idsse/common/http_utils.py
+++ b/python/idsse_common/idsse/common/http_utils.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 class HttpUtils(ProtocolUtils):
     """http Utility Class - Used by DAS for file downloads"""
 
-    def ls(self, path: str, prepend_path: bool = True) -> Sequence[str]:
+    def ls(self, path: str, prepend_path: bool = True, **kwargs) -> Sequence[str]:
         """Execute a 'ls' on the http(s) server
         Args:
             path (str): path
@@ -59,7 +59,12 @@ class HttpUtils(ProtocolUtils):
 
     # pylint: disable=unused-argument
     def cp(
-        self, path: str, dest: str, concurrency: int | None = None, chunk_size: int | None = None
+        self,
+        path: str,
+        dest: str,
+        concurrency: int | None = None,
+        chunk_size: int | None = None,
+        **kwargs,
     ) -> bool:
         """Execute http request download from path to dest.
 

--- a/python/idsse_common/idsse/common/protocol_utils.py
+++ b/python/idsse_common/idsse/common/protocol_utils.py
@@ -31,7 +31,7 @@ class ProtocolUtils(ABC):
 
     # pylint: disable=invalid-name
     @abstractmethod
-    def ls(self, path: str, prepend_path: bool = True) -> Sequence[str]:
+    def ls(self, path: str, prepend_path: bool = True, **kwargs) -> Sequence[str]:
         """Execute a 'ls' on the specified path
 
         Args:
@@ -43,7 +43,7 @@ class ProtocolUtils(ABC):
         """
 
     @abstractmethod
-    def cp(self, path: str, dest: str) -> bool:
+    def cp(self, path: str, dest: str, **kwargs) -> bool:
         """Execute download from path to dest.
 
         Args:
@@ -111,7 +111,8 @@ class ProtocolUtils(ABC):
             time_delta (timedelta): The time step size. Defaults to 1 hour.
             max_workers (int): The number of Python threads to use to make server ls() calls.
                 Defaults to 24, which is reasonable. More threads will not necessarily run faster.
-            kwargs: Additional arguments, e.g. region
+            kwargs: Additional arguments to pass to path_builder, ls(), or cp(), e.g. region,
+                AwsSession, etc.
 
         Returns:
             Sequence[datetime]: A sequence of issue date/times
@@ -137,7 +138,9 @@ class ProtocolUtils(ABC):
             if not (issue_start and dt < issue_start)
         ]
 
-        issues_with_valid_dts = self._get_unique_issues(issue_filepaths, num_issues, max_workers)
+        issues_with_valid_dts = self._get_unique_issues(
+            issue_filepaths, num_issues, max_workers, **kwargs
+        )
         return sorted(list(issues_with_valid_dts), reverse=True)[:num_issues]
 
     def get_valids(
@@ -196,7 +199,7 @@ class ProtocolUtils(ABC):
         return valid_and_file
 
     def _get_unique_issues(
-        self, filepaths: list[str], num_issues: int | None, max_workers: int
+        self, filepaths: list[str], num_issues: int | None, max_workers: int, **kwargs
     ) -> list[datetime]:
         """
         Based on a list of server filepaths, find all issue_dts on the server
@@ -222,7 +225,7 @@ class ProtocolUtils(ABC):
                 filepaths_chunk = paths_to_request[:thread_count]
                 paths_to_request = paths_to_request[thread_count:]
                 futures = [
-                    pool.submit(self._get_issue, dir_path, num_issues)
+                    pool.submit(self._get_issue, dir_path, num_issues, **kwargs)
                     for dir_path in filepaths_chunk
                 ]
 
@@ -236,11 +239,13 @@ class ProtocolUtils(ABC):
 
         return list(ready_issues)
 
-    def _get_issue(self, dir_path: str, num_issues: int = 1) -> list[datetime]:
+    def _get_issue(self, dir_path: str, num_issues: int = 1, **kwargs) -> list[datetime]:
         """Get all objects consistent with the passed directory path and filter by valid range
 
         Args:
             dir_path (str): The directory path
+            num_issues (optional, int): Number of discovered issueDts to return, sorted by most
+                recent first. Defaults to 1.
 
         Returns:
             Sequence[tuple[datetime, str]]: A sequence of tuples with valid date/time (indicated by
@@ -248,13 +253,15 @@ class ProtocolUtils(ABC):
                 found for given time range.
         """
         issues_set: set[datetime] = set()
-        # sort files alphabetically in reverse; this should give us the longest lead time first...
-        # not that that tells us the issueDt is fully available on this server
         # Target child filepaths that end in <file_ext> or <file_ext>/, and get their issuance
-        valid_filepaths_in_dir = sorted(
-            (f for f in self.ls(dir_path) if re.search(rf"{self.path_builder.file_ext}/?$", f)),
-            reverse=True,
+        valid_filepaths_in_dir = (
+            f
+            for f in self.ls(dir_path, **kwargs)
+            if re.search(rf"{self.path_builder.file_ext}/?$", f)
         )
+        # sort files alphabetically in reverse; this should give us the longest lead time first...
+        # note that that tells us the issueDt is fully available on this server
+        valid_filepaths_in_dir = sorted(valid_filepaths_in_dir, reverse=True)
 
         for valid_file_path in valid_filepaths_in_dir:
             try:


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
N/A

### Changes
<!-- Brief description of changes -->
- fix: Boto3Utils does not store persistent `AwsSession`, must be passed in at function call of `ls()`. Requires `ProtocolUtils` to accept generic `**kwargs`

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
N/A