### PR TITLE
fix: jsonschema: vulnerability geometry can be stringified JSON

### DIFF
--- a/python/idsse_common/idsse/common/schema/partner_vulnerability.json
+++ b/python/idsse_common/idsse/common/schema/partner_vulnerability.json
@@ -6,7 +6,7 @@
       "id": { "type": "string" },
       "name": { "type": "string" },
       "primaryOfficeId": { "type": "string" },
-      "geometry": { "type": "object" },
+      "geometry": { "type": ["object", "string"] },
       "activeTime": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
N/A

### Changes
<!-- Brief description of changes -->
- fix: jsonschema: Partner Vulnerability can be stringified GeoJSON or WKT

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
N/A